### PR TITLE
Add upcoming transactions

### DIFF
--- a/api/migrations/007-upcoming-transactions.sql
+++ b/api/migrations/007-upcoming-transactions.sql
@@ -1,0 +1,10 @@
+-- One-time upcoming transactions.
+-- Pending rows are visible for confirmation but do not affect balances
+-- or posted transaction analytics until confirmed.
+ALTER TABLE transactions ADD COLUMN status TEXT NOT NULL DEFAULT 'posted';
+ALTER TABLE transactions ADD COLUMN confirmed_at INTEGER;
+ALTER TABLE transactions ADD COLUMN cancelled_at INTEGER;
+ALTER TABLE transactions ADD COLUMN created_at INTEGER;
+ALTER TABLE transactions ADD COLUMN updated_at INTEGER;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_status_date ON transactions(status, date);

--- a/api/src/controllers/transaction.controller.ts
+++ b/api/src/controllers/transaction.controller.ts
@@ -70,7 +70,14 @@ export class TransactionController {
       await new AuditRepository(c.env.DB).log('UPDATE', 'transaction', id, { amount: body.amount, category_id: body.category_id })
       return c.json(TransactionMapper.toResponseDto(transaction))
     } catch (error: any) {
-      const status = error.message.includes('not found') ? 404 : error.message.includes('locked') ? 409 : 500
+      const message = error.message || ''
+      const status = message.includes('not found')
+        ? 404
+        : message.includes('locked')
+          ? 409
+          : message.includes('cannot be edited') || message.includes('Linked transfers cannot be pending')
+            ? 400
+            : 500
       return c.json({ error: error.message }, status)
     }
   }

--- a/api/src/controllers/transaction.controller.ts
+++ b/api/src/controllers/transaction.controller.ts
@@ -14,6 +14,11 @@ export class TransactionController {
     return c.json(transactions.map(TransactionMapper.toResponseDto))
   }
 
+  async getUpcoming(c: Context) {
+    const transactions = await this.transactionService.getUpcomingTransactions()
+    return c.json(transactions.map(TransactionMapper.toResponseDto))
+  }
+
   async create(c: Context<{ Bindings: Bindings }>) {
     try {
       const body = await c.req.json<CreateTransactionDto>()
@@ -74,6 +79,30 @@ export class TransactionController {
       return c.json({ success: true })
     } catch (error: any) {
       const status = error.message.includes('not found') ? 404 : error.message.includes('locked') ? 409 : 500
+      return c.json({ error: error.message }, status)
+    }
+  }
+
+  async confirm(c: Context<{ Bindings: Bindings }>) {
+    try {
+      const id = c.req.param('id')
+      const transaction = await this.transactionService.confirmTransaction(id)
+      await new AuditRepository(c.env.DB).log('UPDATE', 'transaction', id, { status: 'posted' })
+      return c.json(TransactionMapper.toResponseDto(transaction))
+    } catch (error: any) {
+      const status = error.message.includes('not found') ? 404 : error.message.includes('locked') ? 409 : 400
+      return c.json({ error: error.message }, status)
+    }
+  }
+
+  async decline(c: Context<{ Bindings: Bindings }>) {
+    try {
+      const id = c.req.param('id')
+      const transaction = await this.transactionService.declineTransaction(id)
+      await new AuditRepository(c.env.DB).log('UPDATE', 'transaction', id, { status: 'cancelled' })
+      return c.json(TransactionMapper.toResponseDto(transaction))
+    } catch (error: any) {
+      const status = error.message.includes('not found') ? 404 : error.message.includes('locked') ? 409 : 400
       return c.json({ error: error.message }, status)
     }
   }

--- a/api/src/controllers/transaction.controller.ts
+++ b/api/src/controllers/transaction.controller.ts
@@ -50,6 +50,10 @@ export class TransactionController {
       if (error.message.includes('locked')) {
         return c.json({ error: error.message }, 409)
       }
+
+      if (error.message.includes('Linked transfers cannot be pending')) {
+        return c.json({ error: error.message }, 400)
+      }
       
       return c.json({ 
         error: error.message || 'Failed to create transaction', 

--- a/api/src/controllers/transaction.controller.ts
+++ b/api/src/controllers/transaction.controller.ts
@@ -9,6 +9,11 @@ import { Bindings } from '../types/environment.types'
 export class TransactionController {
   constructor(private transactionService: TransactionService) {}
 
+  private getClientDate(c: Context): string | undefined {
+    const clientDate = c.req.header('X-Client-Date')
+    return clientDate && /^\d{4}-\d{2}-\d{2}$/.test(clientDate) ? clientDate : undefined
+  }
+
   async getAll(c: Context) {
     const transactions = await this.transactionService.getAllTransactions()
     return c.json(transactions.map(TransactionMapper.toResponseDto))
@@ -22,7 +27,7 @@ export class TransactionController {
   async create(c: Context<{ Bindings: Bindings }>) {
     try {
       const body = await c.req.json<CreateTransactionDto>()
-      const result = await this.transactionService.createTransaction(body)
+      const result = await this.transactionService.createTransaction(body, this.getClientDate(c))
 
       // Handle investment transaction response differently
       if ('type' in result && 'quantity' in result) {
@@ -66,7 +71,7 @@ export class TransactionController {
     try {
       const id = c.req.param('id')
       const body = await c.req.json<UpdateTransactionDto>()
-      const transaction = await this.transactionService.updateTransaction(id, body)
+      const transaction = await this.transactionService.updateTransaction(id, body, this.getClientDate(c))
       await new AuditRepository(c.env.DB).log('UPDATE', 'transaction', id, { amount: body.amount, category_id: body.category_id })
       return c.json(TransactionMapper.toResponseDto(transaction))
     } catch (error: any) {
@@ -97,7 +102,7 @@ export class TransactionController {
   async confirm(c: Context<{ Bindings: Bindings }>) {
     try {
       const id = c.req.param('id')
-      const transaction = await this.transactionService.confirmTransaction(id)
+      const transaction = await this.transactionService.confirmTransaction(id, this.getClientDate(c))
       await new AuditRepository(c.env.DB).log('UPDATE', 'transaction', id, { status: 'posted' })
       return c.json(TransactionMapper.toResponseDto(transaction))
     } catch (error: any) {

--- a/api/src/dtos/transaction.dto.ts
+++ b/api/src/dtos/transaction.dto.ts
@@ -1,3 +1,5 @@
+import { TransactionStatus } from '../models/Transaction'
+
 export interface CreateTransactionDto {
   account_id: string
   category_id?: string | null
@@ -7,6 +9,7 @@ export interface CreateTransactionDto {
   price?: number
   linked_transaction_id?: string
   exclude_from_estimate?: boolean
+  status?: Extract<TransactionStatus, 'pending' | 'posted'>
 }
 
 export interface UpdateTransactionDto {
@@ -31,4 +34,9 @@ export interface TransactionResponseDto {
   linked_transaction_id?: string
   exclude_from_estimate?: boolean
   is_recurring?: boolean
+  status: TransactionStatus
+  confirmed_at?: number | null
+  cancelled_at?: number | null
+  created_at?: number | null
+  updated_at?: number | null
 }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -210,6 +210,9 @@ app.delete('/accounts/:id', (c) => getControllers(c).accountController.delete(c)
 // Transactions
 app.get('/transactions', (c) => getControllers(c).transactionController.getAll(c))
 app.post('/transactions', validateBody(CreateTransactionSchema), (c) => getControllers(c).transactionController.create(c))
+app.get('/transactions/upcoming', (c) => getControllers(c).transactionController.getUpcoming(c))
+app.post('/transactions/:id/confirm', (c) => getControllers(c).transactionController.confirm(c))
+app.post('/transactions/:id/decline', (c) => getControllers(c).transactionController.decline(c))
 app.put('/transactions/:id', validateBody(UpdateTransactionSchema), (c) => getControllers(c).transactionController.update(c))
 app.delete('/transactions/:id', (c) => getControllers(c).transactionController.delete(c))
 

--- a/api/src/mappers/transaction.mapper.ts
+++ b/api/src/mappers/transaction.mapper.ts
@@ -13,7 +13,12 @@ export class TransactionMapper {
       price: transaction.price,
       linked_transaction_id: transaction.linked_transaction_id,
       exclude_from_estimate: transaction.exclude_from_estimate,
-      is_recurring: transaction.is_recurring
+      is_recurring: transaction.is_recurring,
+      status: transaction.status || 'posted',
+      confirmed_at: transaction.confirmed_at,
+      cancelled_at: transaction.cancelled_at,
+      created_at: transaction.created_at,
+      updated_at: transaction.updated_at
     }
   }
 }

--- a/api/src/middlewares/cors.middleware.ts
+++ b/api/src/middlewares/cors.middleware.ts
@@ -32,7 +32,7 @@ export async function corsMiddleware(c: Context<{ Bindings: Bindings }>, next: N
 
   // Set CORS headers for allowed origins
   c.header('Access-Control-Allow-Origin', origin)
-  c.header('Access-Control-Allow-Headers', 'Content-Type, X-API-Key')
+  c.header('Access-Control-Allow-Headers', 'Content-Type, X-API-Key, X-Client-Date')
   c.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
 
   // Handle preflight requests - return early without API key check

--- a/api/src/models/Transaction.ts
+++ b/api/src/models/Transaction.ts
@@ -1,3 +1,5 @@
+export type TransactionStatus = 'posted' | 'pending' | 'cancelled'
+
 export interface Transaction {
   id: string
   account_id: string
@@ -9,4 +11,9 @@ export interface Transaction {
   linked_transaction_id?: string
   exclude_from_estimate?: boolean
   is_recurring?: boolean
+  status?: TransactionStatus
+  confirmed_at?: number | null
+  cancelled_at?: number | null
+  created_at?: number | null
+  updated_at?: number | null
 }

--- a/api/src/repositories/transaction.repository.ts
+++ b/api/src/repositories/transaction.repository.ts
@@ -1,7 +1,8 @@
-import { Transaction } from '../models/Transaction'
+import { Transaction, TransactionStatus } from '../models/Transaction'
 
 type RawTransactionRow = Omit<Transaction, 'exclude_from_estimate'> & {
   exclude_from_estimate: number
+  status?: TransactionStatus | null
 }
 
 type RawExpenseRow = RawTransactionRow & {
@@ -17,12 +18,13 @@ export class TransactionRepository {
   private mapTransaction(raw: RawTransactionRow): Transaction {
     return {
       ...raw,
-      exclude_from_estimate: raw.exclude_from_estimate === 1
+      exclude_from_estimate: raw.exclude_from_estimate === 1,
+      status: raw.status || 'posted'
     }
   }
 
   async findAll(): Promise<Transaction[]> {
-    const { results } = await this.db.prepare('SELECT * FROM transactions ORDER BY date DESC, rowid DESC').all<RawTransactionRow>()
+    const { results } = await this.db.prepare("SELECT * FROM transactions WHERE status = 'posted' ORDER BY date DESC, rowid DESC").all<RawTransactionRow>()
     return results.map(r => this.mapTransaction(r))
   }
 
@@ -33,7 +35,7 @@ export class TransactionRepository {
 
   async create(transaction: Transaction): Promise<void> {
     await this.db.prepare(
-      'INSERT INTO transactions (id, account_id, category_id, amount, description, date, linked_transaction_id, exclude_from_estimate) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+      'INSERT INTO transactions (id, account_id, category_id, amount, description, date, linked_transaction_id, exclude_from_estimate, status, confirmed_at, cancelled_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
     ).bind(
       transaction.id,
       transaction.account_id,
@@ -42,7 +44,12 @@ export class TransactionRepository {
       transaction.description || null,
       transaction.date,
       transaction.linked_transaction_id || null,
-      transaction.exclude_from_estimate ? 1 : 0
+      transaction.exclude_from_estimate ? 1 : 0,
+      transaction.status || 'posted',
+      transaction.confirmed_at ?? null,
+      transaction.cancelled_at ?? null,
+      transaction.created_at ?? Date.now(),
+      transaction.updated_at ?? Date.now()
     ).run()
   }
 
@@ -74,6 +81,26 @@ export class TransactionRepository {
       fields.push('exclude_from_estimate = ?')
       values.push(updates.exclude_from_estimate ? 1 : 0)
     }
+    if (updates.status !== undefined) {
+      fields.push('status = ?')
+      values.push(updates.status)
+    }
+    if (updates.confirmed_at !== undefined) {
+      fields.push('confirmed_at = ?')
+      values.push(updates.confirmed_at)
+    }
+    if (updates.cancelled_at !== undefined) {
+      fields.push('cancelled_at = ?')
+      values.push(updates.cancelled_at)
+    }
+    if (updates.created_at !== undefined) {
+      fields.push('created_at = ?')
+      values.push(updates.created_at)
+    }
+    if (updates.updated_at !== undefined) {
+      fields.push('updated_at = ?')
+      values.push(updates.updated_at)
+    }
 
     values.push(id)
 
@@ -96,18 +123,18 @@ export class TransactionRepository {
     const order = sortOrder.toLowerCase() === 'asc' ? 'ASC' : 'DESC'
 
     const { results } = await this.db.prepare(
-      `SELECT * FROM transactions ORDER BY ${field} ${order}, rowid DESC LIMIT ? OFFSET ?`
+      `SELECT * FROM transactions WHERE status = 'posted' ORDER BY ${field} ${order}, rowid DESC LIMIT ? OFFSET ?`
     ).bind(limit, offset).all<RawTransactionRow>()
     return results.map(r => this.mapTransaction(r))
   }
 
   async count(): Promise<number> {
-    const result = await this.db.prepare('SELECT COUNT(*) as count FROM transactions').first<{ count: number }>()
+    const result = await this.db.prepare("SELECT COUNT(*) as count FROM transactions WHERE status = 'posted'").first<{ count: number }>()
     return result?.count || 0
   }
 
   async findByDateRange(startDate: string, endDate: string, accountId?: string, categoryId?: string): Promise<Transaction[]> {
-    let query = 'SELECT * FROM transactions WHERE date >= ? AND date <= ?'
+    let query = "SELECT * FROM transactions WHERE status = 'posted' AND date >= ? AND date <= ?"
     const params: D1Value[] = [startDate, endDate]
 
     if (accountId) {
@@ -127,7 +154,7 @@ export class TransactionRepository {
   }
 
   async findFromDate(startDate: string, accountId?: string, categoryId?: string): Promise<Transaction[]> {
-    let query = 'SELECT * FROM transactions WHERE date >= ?'
+    let query = "SELECT * FROM transactions WHERE status = 'posted' AND date >= ?"
     const params: D1Value[] = [startDate]
 
     if (accountId) {
@@ -147,15 +174,22 @@ export class TransactionRepository {
   }
 
   async findRecurring(): Promise<Transaction[]> {
-    const { results } = await this.db.prepare('SELECT * FROM transactions WHERE is_recurring = 1').all<RawTransactionRow>()
+    const { results } = await this.db.prepare("SELECT * FROM transactions WHERE status = 'posted' AND is_recurring = 1").all<RawTransactionRow>()
     return results.map(r => this.mapTransaction(r))
   }
 
   async findByAccountAndDatePattern(accountId: string, amount: number, description: string, datePattern: string): Promise<Transaction | null> {
     const result = await this.db.prepare(
-      'SELECT * FROM transactions WHERE account_id = ? AND amount = ? AND description = ? AND date LIKE ?'
+      "SELECT * FROM transactions WHERE status = 'posted' AND account_id = ? AND amount = ? AND description = ? AND date LIKE ?"
     ).bind(accountId, amount, description, datePattern).first<RawTransactionRow>()
     return result ? this.mapTransaction(result) : null
+  }
+
+  async findUpcoming(): Promise<Transaction[]> {
+    const { results } = await this.db.prepare(
+      "SELECT * FROM transactions WHERE status = 'pending' ORDER BY date ASC, rowid DESC"
+    ).all<RawTransactionRow>()
+    return results.map(r => this.mapTransaction(r))
   }
 
   async findRecentExpensesFromCashAccounts(startDate: string, endDate: string): Promise<(Transaction & { account_name: string; category_name?: string })[]> {
@@ -166,6 +200,7 @@ export class TransactionRepository {
       LEFT JOIN categories c ON t.category_id = c.id
       WHERE a.type = 'cash'
         AND t.amount < 0
+        AND t.status = 'posted'
         AND t.date >= ?
         AND t.date <= ?
       ORDER BY t.date DESC

--- a/api/src/repositories/transaction.repository.ts
+++ b/api/src/repositories/transaction.repository.ts
@@ -192,6 +192,24 @@ export class TransactionRepository {
     return results.map(r => this.mapTransaction(r))
   }
 
+  async confirmPendingAndApplyBalance(transaction: Transaction, now: number, today: string): Promise<boolean> {
+    const confirmationToken = `confirming:${crypto.randomUUID()}`
+
+    const [claimResult, balanceResult, postResult] = await this.db.batch([
+      this.db.prepare(
+        "UPDATE transactions SET status = ?, updated_at = ? WHERE id = ? AND status = 'pending' AND linked_transaction_id IS NULL AND date <= ?"
+      ).bind(confirmationToken, now, transaction.id, today),
+      this.db.prepare(
+        'UPDATE accounts SET balance = balance + ?, updated_at = ? WHERE id = ? AND EXISTS (SELECT 1 FROM transactions WHERE id = ? AND status = ?)'
+      ).bind(transaction.amount, now, transaction.account_id, transaction.id, confirmationToken),
+      this.db.prepare(
+        "UPDATE transactions SET status = 'posted', confirmed_at = ?, cancelled_at = NULL, updated_at = ? WHERE id = ? AND status = ?"
+      ).bind(now, now, transaction.id, confirmationToken),
+    ])
+
+    return claimResult.meta.changes === 1 && balanceResult.meta.changes === 1 && postResult.meta.changes === 1
+  }
+
   async findRecentExpensesFromCashAccounts(startDate: string, endDate: string): Promise<(Transaction & { account_name: string; category_name?: string })[]> {
     const query = `
       SELECT t.*, a.name as account_name, c.name as category_name

--- a/api/src/repositories/transaction.repository.ts
+++ b/api/src/repositories/transaction.repository.ts
@@ -195,7 +195,7 @@ export class TransactionRepository {
   async confirmPendingAndApplyBalance(transaction: Transaction, now: number, today: string): Promise<boolean> {
     const confirmationToken = `confirming:${crypto.randomUUID()}`
 
-    const [claimResult, balanceResult, postResult] = await this.db.batch([
+    const [claimResult, balanceResult, postResult, cleanupResult] = await this.db.batch([
       this.db.prepare(
         "UPDATE transactions SET status = ?, updated_at = ? WHERE id = ? AND status = 'pending' AND linked_transaction_id IS NULL AND date <= ? AND EXISTS (SELECT 1 FROM accounts WHERE id = ?)"
       ).bind(confirmationToken, now, transaction.id, today, transaction.account_id),
@@ -210,7 +210,10 @@ export class TransactionRepository {
       ).bind(now, transaction.id, confirmationToken, transaction.account_id, now),
     ])
 
-    return claimResult.meta.changes === 1 && balanceResult.meta.changes === 1 && postResult.meta.changes === 1
+    return claimResult.meta.changes === 1
+      && balanceResult.meta.changes === 1
+      && postResult.meta.changes === 1
+      && cleanupResult.meta.changes === 0
   }
 
   async findRecentExpensesFromCashAccounts(startDate: string, endDate: string): Promise<(Transaction & { account_name: string; category_name?: string })[]> {

--- a/api/src/repositories/transaction.repository.ts
+++ b/api/src/repositories/transaction.repository.ts
@@ -197,14 +197,17 @@ export class TransactionRepository {
 
     const [claimResult, balanceResult, postResult] = await this.db.batch([
       this.db.prepare(
-        "UPDATE transactions SET status = ?, updated_at = ? WHERE id = ? AND status = 'pending' AND linked_transaction_id IS NULL AND date <= ?"
-      ).bind(confirmationToken, now, transaction.id, today),
+        "UPDATE transactions SET status = ?, updated_at = ? WHERE id = ? AND status = 'pending' AND linked_transaction_id IS NULL AND date <= ? AND EXISTS (SELECT 1 FROM accounts WHERE id = ?)"
+      ).bind(confirmationToken, now, transaction.id, today, transaction.account_id),
       this.db.prepare(
         'UPDATE accounts SET balance = balance + ?, updated_at = ? WHERE id = ? AND EXISTS (SELECT 1 FROM transactions WHERE id = ? AND status = ?)'
       ).bind(transaction.amount, now, transaction.account_id, transaction.id, confirmationToken),
       this.db.prepare(
-        "UPDATE transactions SET status = 'posted', confirmed_at = ?, cancelled_at = NULL, updated_at = ? WHERE id = ? AND status = ?"
-      ).bind(now, now, transaction.id, confirmationToken),
+        "UPDATE transactions SET status = 'posted', confirmed_at = ?, cancelled_at = NULL, updated_at = ? WHERE id = ? AND status = ? AND EXISTS (SELECT 1 FROM accounts WHERE id = ? AND updated_at = ?)"
+      ).bind(now, now, transaction.id, confirmationToken, transaction.account_id, now),
+      this.db.prepare(
+        "UPDATE transactions SET status = 'pending', updated_at = ? WHERE id = ? AND status = ? AND NOT EXISTS (SELECT 1 FROM accounts WHERE id = ? AND updated_at = ?)"
+      ).bind(now, transaction.id, confirmationToken, transaction.account_id, now),
     ])
 
     return claimResult.meta.changes === 1 && balanceResult.meta.changes === 1 && postResult.meta.changes === 1

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -60,6 +60,9 @@ export function setupRoutes(
   // Transactions
   app.get('/transactions', (c) => transactionController.getAll(c))
   app.post('/transactions', (c) => transactionController.create(c))
+  app.get('/transactions/upcoming', (c) => transactionController.getUpcoming(c))
+  app.post('/transactions/:id/confirm', (c) => transactionController.confirm(c))
+  app.post('/transactions/:id/decline', (c) => transactionController.decline(c))
   app.put('/transactions/:id', (c) => transactionController.update(c))
   app.delete('/transactions/:id', (c) => transactionController.delete(c))
 

--- a/api/src/services/transaction.service.ts
+++ b/api/src/services/transaction.service.ts
@@ -382,6 +382,10 @@ export class TransactionService {
       throw new Error('Transaction is not pending confirmation')
     }
 
+    if (tx.date > this.todayString()) {
+      throw new Error('Cannot confirm a transaction dated in the future')
+    }
+
     const account = await this.accountRepo.findById(tx.account_id)
     if (!account) {
       throw new Error('Account not found')

--- a/api/src/services/transaction.service.ts
+++ b/api/src/services/transaction.service.ts
@@ -378,6 +378,10 @@ export class TransactionService {
       throw new Error('Linked transfers cannot be confirmed as upcoming transactions')
     }
 
+    if ((tx.status || 'posted') === 'posted') {
+      return tx
+    }
+
     if ((tx.status || 'posted') !== 'pending') {
       throw new Error('Transaction is not pending confirmation')
     }
@@ -393,15 +397,13 @@ export class TransactionService {
     this.assertAccountUnlocked(account)
 
     const now = Date.now()
-    await this.accountRepo.updateBalance(tx.account_id, account.balance + tx.amount, now)
-    await this.transactionRepo.update(id, {
-      status: 'posted',
-      confirmed_at: now,
-      cancelled_at: null,
-      updated_at: now
-    })
+    const confirmed = await this.transactionRepo.confirmPendingAndApplyBalance(tx, now, this.todayString())
 
     const updated = await this.transactionRepo.findById(id)
+    if (!confirmed && updated?.status !== 'posted') {
+      throw new Error('Transaction is not pending confirmation')
+    }
+
     return updated!
   }
 

--- a/api/src/services/transaction.service.ts
+++ b/api/src/services/transaction.service.ts
@@ -298,7 +298,8 @@ export class TransactionService {
       amount: -amountFrom,
       description: outgoingDescription,
       date,
-      exclude_from_estimate: false
+      exclude_from_estimate: false,
+      updated_at: now
     })
 
     await this.transactionRepo.update(incoming.id, {
@@ -307,7 +308,8 @@ export class TransactionService {
       amount: amountTo,
       description: incomingDescription,
       date,
-      exclude_from_estimate: false
+      exclude_from_estimate: false,
+      updated_at: now
     })
 
     const updated = await this.transactionRepo.findById(requestedId)

--- a/api/src/services/transaction.service.ts
+++ b/api/src/services/transaction.service.ts
@@ -21,35 +21,35 @@ export class TransactionService {
     }
   }
 
-  private todayString(): string {
-    return new Date().toISOString().slice(0, 10)
+  private todayString(today?: string): string {
+    return today || new Date().toISOString().slice(0, 10)
   }
 
   private isPosted(transaction: Transaction): boolean {
     return (transaction.status || 'posted') === 'posted'
   }
 
-  private resolveCreateStatus(dto: CreateTransactionDto): TransactionStatus {
-    if (dto.status === 'pending' || dto.date > this.todayString()) {
+  private resolveCreateStatus(dto: CreateTransactionDto, today?: string): TransactionStatus {
+    if (dto.status === 'pending' || dto.date > this.todayString(today)) {
       return 'pending'
     }
     return 'posted'
   }
 
-  private resolveUpdateStatus(oldTx: Transaction, dto: UpdateTransactionDto): TransactionStatus {
+  private resolveUpdateStatus(oldTx: Transaction, dto: UpdateTransactionDto, today?: string): TransactionStatus {
     if ((oldTx.status || 'posted') === 'pending') {
       return 'pending'
     }
 
     const nextDate = dto.date || oldTx.date
-    return nextDate > this.todayString() ? 'pending' : 'posted'
+    return nextDate > this.todayString(today) ? 'pending' : 'posted'
   }
 
   async getAllTransactions(): Promise<Transaction[]> {
     return await this.transactionRepo.findAll()
   }
 
-  async createTransaction(dto: CreateTransactionDto): Promise<Transaction | { type: string; quantity: number; price: number; total_amount: number }> {
+  async createTransaction(dto: CreateTransactionDto, today?: string): Promise<Transaction | { type: string; quantity: number; price: number; total_amount: number }> {
     const id = crypto.randomUUID()
 
     // Get account to check if it's an investment account
@@ -110,7 +110,7 @@ export class TransactionService {
 
     // For non-investment accounts: use regular transactions table
     const now = Date.now()
-    const status = this.resolveCreateStatus(dto)
+    const status = this.resolveCreateStatus(dto, today)
 
     if (dto.linked_transaction_id && status === 'pending') {
       throw new Error('Linked transfers cannot be pending; use the /transfers endpoint')
@@ -142,7 +142,7 @@ export class TransactionService {
     return transaction
   }
 
-  async updateTransaction(id: string, dto: UpdateTransactionDto): Promise<Transaction> {
+  async updateTransaction(id: string, dto: UpdateTransactionDto, today?: string): Promise<Transaction> {
     // Get old transaction to adjust balance
     const oldTx = await this.transactionRepo.findById(id)
 
@@ -173,7 +173,7 @@ export class TransactionService {
 
     const newAccountId = dto.account_id || oldTx.account_id
     const newAmount = dto.amount ?? oldTx.amount
-    const newStatus = this.resolveUpdateStatus(oldTx, dto)
+    const newStatus = this.resolveUpdateStatus(oldTx, dto, today)
     const now = Date.now()
     if (newAccountId !== oldTx.account_id) {
       const targetAccount = await this.accountRepo.findById(newAccountId)
@@ -367,7 +367,7 @@ export class TransactionService {
     return await this.transactionRepo.findUpcoming()
   }
 
-  async confirmTransaction(id: string): Promise<Transaction> {
+  async confirmTransaction(id: string, today?: string): Promise<Transaction> {
     const tx = await this.transactionRepo.findById(id)
 
     if (!tx) {
@@ -386,7 +386,8 @@ export class TransactionService {
       throw new Error('Transaction is not pending confirmation')
     }
 
-    if (tx.date > this.todayString()) {
+    const effectiveToday = this.todayString(today)
+    if (tx.date > effectiveToday) {
       throw new Error('Cannot confirm a transaction dated in the future')
     }
 
@@ -397,7 +398,7 @@ export class TransactionService {
     this.assertAccountUnlocked(account)
 
     const now = Date.now()
-    const confirmed = await this.transactionRepo.confirmPendingAndApplyBalance(tx, now, this.todayString())
+    const confirmed = await this.transactionRepo.confirmPendingAndApplyBalance(tx, now, effectiveToday)
 
     const updated = await this.transactionRepo.findById(id)
     if (!confirmed && updated?.status !== 'posted') {

--- a/api/src/services/transaction.service.ts
+++ b/api/src/services/transaction.service.ts
@@ -1,4 +1,4 @@
-import { Transaction } from '../models/Transaction'
+import { Transaction, TransactionStatus } from '../models/Transaction'
 import { InvestmentTransaction } from '../models/InvestmentTransaction'
 import { Account } from '../models/Account'
 import { TransactionRepository } from '../repositories/transaction.repository'
@@ -6,7 +6,7 @@ import { AccountRepository } from '../repositories/account.repository'
 import { InvestmentTransactionRepository } from '../repositories/investment-transaction.repository'
 import { CreateTransactionDto, UpdateTransactionDto } from '../dtos/transaction.dto'
 import { fetchPriceFromYahoo } from '../utils/yahoo-finance.util'
-import { PaginatedResponse, PaginationHelper, PaginationParams, DateFilterParams } from '../models/Pagination'
+import { PaginatedResponse, PaginationHelper, PaginationParams } from '../models/Pagination'
 
 export class TransactionService {
   constructor(
@@ -19,6 +19,30 @@ export class TransactionService {
     if (account.is_locked) {
       throw new Error(`Account "${account.name}" is locked`)
     }
+  }
+
+  private todayString(): string {
+    return new Date().toISOString().slice(0, 10)
+  }
+
+  private isPosted(transaction: Transaction): boolean {
+    return (transaction.status || 'posted') === 'posted'
+  }
+
+  private resolveCreateStatus(dto: CreateTransactionDto): TransactionStatus {
+    if (dto.status === 'pending' || dto.date > this.todayString()) {
+      return 'pending'
+    }
+    return 'posted'
+  }
+
+  private resolveUpdateStatus(oldTx: Transaction, dto: UpdateTransactionDto): TransactionStatus {
+    if ((oldTx.status || 'posted') === 'pending') {
+      return 'pending'
+    }
+
+    const nextDate = dto.date || oldTx.date
+    return nextDate > this.todayString() ? 'pending' : 'posted'
   }
 
   async getAllTransactions(): Promise<Transaction[]> {
@@ -85,6 +109,8 @@ export class TransactionService {
     }
 
     // For non-investment accounts: use regular transactions table
+    const now = Date.now()
+    const status = this.resolveCreateStatus(dto)
     const transaction: Transaction = {
       id,
       account_id: dto.account_id,
@@ -93,14 +119,20 @@ export class TransactionService {
       description: dto.description,
       date: dto.date,
       linked_transaction_id: dto.linked_transaction_id,
-      exclude_from_estimate: dto.exclude_from_estimate
+      exclude_from_estimate: dto.exclude_from_estimate,
+      status,
+      confirmed_at: status === 'posted' ? now : null,
+      cancelled_at: null,
+      created_at: now,
+      updated_at: now
     }
 
     await this.transactionRepo.create(transaction)
 
-    // Update account balance
-    const newBalance = account.balance + dto.amount
-    await this.accountRepo.updateBalance(dto.account_id, newBalance, Date.now())
+    if (status === 'posted') {
+      const newBalance = account.balance + dto.amount
+      await this.accountRepo.updateBalance(dto.account_id, newBalance, now)
+    }
 
     return transaction
   }
@@ -111,6 +143,10 @@ export class TransactionService {
 
     if (!oldTx) {
       throw new Error('Transaction not found')
+    }
+
+    if ((oldTx.status || 'posted') === 'cancelled') {
+      throw new Error('Cancelled transaction cannot be edited')
     }
 
     if (oldTx.linked_transaction_id) {
@@ -128,6 +164,8 @@ export class TransactionService {
 
     const newAccountId = dto.account_id || oldTx.account_id
     const newAmount = dto.amount ?? oldTx.amount
+    const newStatus = this.resolveUpdateStatus(oldTx, dto)
+    const now = Date.now()
     if (newAccountId !== oldTx.account_id) {
       const targetAccount = await this.accountRepo.findById(newAccountId)
       if (!targetAccount) {
@@ -136,12 +174,13 @@ export class TransactionService {
       this.assertAccountUnlocked(targetAccount)
     }
 
-    // Revert old balance
-    await this.accountRepo.updateBalance(
-      oldTx.account_id,
-      oldAccount.balance - oldTx.amount,
-      Date.now()
-    )
+    if (this.isPosted(oldTx)) {
+      await this.accountRepo.updateBalance(
+        oldTx.account_id,
+        oldAccount.balance - oldTx.amount,
+        now
+      )
+    }
 
     // Update transaction
     await this.transactionRepo.update(id, {
@@ -150,19 +189,24 @@ export class TransactionService {
       amount: newAmount,
       description: dto.description !== undefined ? dto.description : oldTx.description,
       date: dto.date || oldTx.date,
-      exclude_from_estimate: dto.exclude_from_estimate !== undefined ? dto.exclude_from_estimate : oldTx.exclude_from_estimate
+      exclude_from_estimate: dto.exclude_from_estimate !== undefined ? dto.exclude_from_estimate : oldTx.exclude_from_estimate,
+      status: newStatus,
+      confirmed_at: newStatus === 'posted' ? (oldTx.confirmed_at ?? now) : null,
+      cancelled_at: null,
+      updated_at: now
     })
 
-    // Apply new balance
-    const newAccount = await this.accountRepo.findById(newAccountId)
-    if (!newAccount) {
-      throw new Error('Account not found')
+    if (newStatus === 'posted') {
+      const newAccount = await this.accountRepo.findById(newAccountId)
+      if (!newAccount) {
+        throw new Error('Account not found')
+      }
+      await this.accountRepo.updateBalance(
+        newAccountId,
+        newAccount.balance + newAmount,
+        now
+      )
     }
-    await this.accountRepo.updateBalance(
-      newAccountId,
-      newAccount.balance + newAmount,
-      Date.now()
-    )
 
     const updated = await this.transactionRepo.findById(id)
     return updated!
@@ -285,7 +329,7 @@ export class TransactionService {
       }
 
       // Revert balance for the main transaction
-      if (account) {
+      if (account && this.isPosted(tx)) {
         await this.accountRepo.updateBalance(
           tx.account_id,
           account.balance - tx.amount,
@@ -295,7 +339,7 @@ export class TransactionService {
 
       // If this is a transfer (has linked_transaction_id), delete the linked transaction too
       if (linkedTx) {
-        if (linkedAccount) {
+        if (linkedAccount && this.isPosted(linkedTx)) {
           await this.accountRepo.updateBalance(
             linkedTx.account_id,
             linkedAccount.balance - linkedTx.amount,
@@ -308,6 +352,72 @@ export class TransactionService {
       // Delete the main transaction
       await this.transactionRepo.delete(id)
     }
+  }
+
+  async getUpcomingTransactions(): Promise<Transaction[]> {
+    return await this.transactionRepo.findUpcoming()
+  }
+
+  async confirmTransaction(id: string): Promise<Transaction> {
+    const tx = await this.transactionRepo.findById(id)
+
+    if (!tx) {
+      throw new Error('Transaction not found')
+    }
+
+    if (tx.linked_transaction_id) {
+      throw new Error('Linked transfers cannot be confirmed as upcoming transactions')
+    }
+
+    if ((tx.status || 'posted') !== 'pending') {
+      throw new Error('Transaction is not pending confirmation')
+    }
+
+    const account = await this.accountRepo.findById(tx.account_id)
+    if (!account) {
+      throw new Error('Account not found')
+    }
+    this.assertAccountUnlocked(account)
+
+    const now = Date.now()
+    await this.accountRepo.updateBalance(tx.account_id, account.balance + tx.amount, now)
+    await this.transactionRepo.update(id, {
+      status: 'posted',
+      confirmed_at: now,
+      cancelled_at: null,
+      updated_at: now
+    })
+
+    const updated = await this.transactionRepo.findById(id)
+    return updated!
+  }
+
+  async declineTransaction(id: string): Promise<Transaction> {
+    const tx = await this.transactionRepo.findById(id)
+
+    if (!tx) {
+      throw new Error('Transaction not found')
+    }
+
+    if ((tx.status || 'posted') !== 'pending') {
+      throw new Error('Transaction is not pending confirmation')
+    }
+
+    const account = await this.accountRepo.findById(tx.account_id)
+    if (!account) {
+      throw new Error('Account not found')
+    }
+    this.assertAccountUnlocked(account)
+
+    const now = Date.now()
+    await this.transactionRepo.update(id, {
+      status: 'cancelled',
+      cancelled_at: now,
+      updated_at: now
+    })
+
+    const updated = await this.transactionRepo.findById(id)
+    return updated!
   }
 
   async cloneRecurringTransactions(): Promise<void> {

--- a/api/src/services/transaction.service.ts
+++ b/api/src/services/transaction.service.ts
@@ -111,6 +111,11 @@ export class TransactionService {
     // For non-investment accounts: use regular transactions table
     const now = Date.now()
     const status = this.resolveCreateStatus(dto)
+
+    if (dto.linked_transaction_id && status === 'pending') {
+      throw new Error('Linked transfers cannot be pending; use the /transfers endpoint')
+    }
+
     const transaction: Transaction = {
       id,
       account_id: dto.account_id,
@@ -150,6 +155,10 @@ export class TransactionService {
     }
 
     if (oldTx.linked_transaction_id) {
+      if (!this.isPosted(oldTx)) {
+        throw new Error('Linked transfers cannot be pending')
+      }
+
       const linkedTx = await this.transactionRepo.findById(oldTx.linked_transaction_id)
       if (linkedTx) {
         return await this.updateTransferPair(oldTx, linkedTx, dto)
@@ -397,6 +406,10 @@ export class TransactionService {
 
     if (!tx) {
       throw new Error('Transaction not found')
+    }
+
+    if (tx.linked_transaction_id) {
+      throw new Error('Linked transfers cannot be declined as upcoming transactions')
     }
 
     if ((tx.status || 'posted') !== 'pending') {

--- a/api/src/tests/upcoming-transactions.test.ts
+++ b/api/src/tests/upcoming-transactions.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest'
+import { TransactionService } from '../services/transaction.service'
+import { Account } from '../models/Account'
+import { Transaction } from '../models/Transaction'
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+  return {
+    id: 'account-1',
+    name: 'Checking',
+    type: 'cash',
+    balance: 1000,
+    currency: 'HUF',
+    updated_at: Date.now(),
+    ...overrides,
+  }
+}
+
+function createService(transactions: Record<string, Transaction>, accounts: Record<string, Account>) {
+  const transactionRepo = {
+    findById: vi.fn(async (id: string) => transactions[id] || null),
+    create: vi.fn(async (transaction: Transaction) => {
+      transactions[transaction.id] = transaction
+    }),
+    update: vi.fn(async (id: string, updates: Partial<Transaction>) => {
+      transactions[id] = { ...transactions[id], ...updates }
+    }),
+    findUpcoming: vi.fn(async () => Object.values(transactions).filter(tx => tx.status === 'pending')),
+  }
+
+  const accountRepo = {
+    findById: vi.fn(async (id: string) => accounts[id] || null),
+    updateBalance: vi.fn(async (id: string, balance: number, updated_at: number) => {
+      if (accounts[id]) {
+        accounts[id].balance = balance
+        accounts[id].updated_at = updated_at
+      }
+    }),
+  }
+
+  const service = new TransactionService(
+    transactionRepo as any,
+    accountRepo as any,
+    { create: vi.fn() } as any
+  )
+
+  return { service, transactionRepo, accountRepo }
+}
+
+describe('upcoming transactions', () => {
+  it('creates future cash transactions as pending without changing balance', async () => {
+    const accounts = { 'account-1': makeAccount() }
+    const transactions: Record<string, Transaction> = {}
+    const { service, accountRepo } = createService(transactions, accounts)
+
+    const result = await service.createTransaction({
+      account_id: 'account-1',
+      amount: 500,
+      date: '2999-01-01',
+      description: 'Future salary',
+    })
+
+    expect('status' in result && result.status).toBe('pending')
+    expect(accounts['account-1'].balance).toBe(1000)
+    expect(accountRepo.updateBalance).not.toHaveBeenCalled()
+  })
+
+  it('confirms a pending transaction and applies it once', async () => {
+    const accounts = { 'account-1': makeAccount() }
+    const transactions: Record<string, Transaction> = {
+      'tx-1': {
+        id: 'tx-1',
+        account_id: 'account-1',
+        amount: 500,
+        date: '2026-07-07',
+        status: 'pending',
+      },
+    }
+    const { service, accountRepo } = createService(transactions, accounts)
+
+    const result = await service.confirmTransaction('tx-1')
+
+    expect(result.status).toBe('posted')
+    expect(result.confirmed_at).toEqual(expect.any(Number))
+    expect(accounts['account-1'].balance).toBe(1500)
+    expect(accountRepo.updateBalance).toHaveBeenCalledTimes(1)
+  })
+
+  it('declines a pending transaction without changing balance', async () => {
+    const accounts = { 'account-1': makeAccount() }
+    const transactions: Record<string, Transaction> = {
+      'tx-1': {
+        id: 'tx-1',
+        account_id: 'account-1',
+        amount: 500,
+        date: '2026-07-07',
+        status: 'pending',
+      },
+    }
+    const { service, accountRepo } = createService(transactions, accounts)
+
+    const result = await service.declineTransaction('tx-1')
+
+    expect(result.status).toBe('cancelled')
+    expect(result.cancelled_at).toEqual(expect.any(Number))
+    expect(accounts['account-1'].balance).toBe(1000)
+    expect(accountRepo.updateBalance).not.toHaveBeenCalled()
+  })
+
+  it('keeps edited pending transactions pending', async () => {
+    const accounts = { 'account-1': makeAccount() }
+    const transactions: Record<string, Transaction> = {
+      'tx-1': {
+        id: 'tx-1',
+        account_id: 'account-1',
+        amount: 500,
+        date: '2999-01-01',
+        status: 'pending',
+      },
+    }
+    const { service, accountRepo } = createService(transactions, accounts)
+
+    const result = await service.updateTransaction('tx-1', {
+      amount: 700,
+      date: '2026-07-07',
+    })
+
+    expect(result.status).toBe('pending')
+    expect(result.amount).toBe(700)
+    expect(accounts['account-1'].balance).toBe(1000)
+    expect(accountRepo.updateBalance).not.toHaveBeenCalled()
+  })
+})

--- a/api/src/tests/upcoming-transactions.test.ts
+++ b/api/src/tests/upcoming-transactions.test.ts
@@ -80,6 +80,23 @@ describe('upcoming transactions', () => {
     expect(accountRepo.updateBalance).not.toHaveBeenCalled()
   })
 
+  it('uses the supplied client date when deciding whether a new transaction is upcoming', async () => {
+    const accounts = { 'account-1': makeAccount() }
+    const transactions: Record<string, Transaction> = {}
+    const { service, accountRepo } = createService(transactions, accounts)
+
+    const result = await service.createTransaction({
+      account_id: 'account-1',
+      amount: 500,
+      date: '2999-01-01',
+      description: 'Local today salary',
+    }, '2999-01-01')
+
+    expect('status' in result && result.status).toBe('posted')
+    expect(accounts['account-1'].balance).toBe(1500)
+    expect(accountRepo.updateBalance).toHaveBeenCalledTimes(1)
+  })
+
   it('rejects linked transfer transactions that would become pending', async () => {
     const accounts = { 'account-1': makeAccount() }
     const transactions: Record<string, Transaction> = {}
@@ -222,6 +239,27 @@ describe('upcoming transactions', () => {
       .rejects.toThrow('Cannot confirm a transaction dated in the future')
 
     expect(transactionRepo.update).not.toHaveBeenCalled()
+    expect(accountRepo.updateBalance).not.toHaveBeenCalled()
+  })
+
+  it('uses the supplied client date when confirming a pending transaction', async () => {
+    const accounts = { 'account-1': makeAccount() }
+    const transactions: Record<string, Transaction> = {
+      'tx-1': {
+        id: 'tx-1',
+        account_id: 'account-1',
+        amount: 500,
+        date: '2999-01-01',
+        status: 'pending',
+      },
+    }
+    const { service, transactionRepo, accountRepo } = createService(transactions, accounts)
+
+    const result = await service.confirmTransaction('tx-1', '2999-01-01')
+
+    expect(result.status).toBe('posted')
+    expect(accounts['account-1'].balance).toBe(1500)
+    expect(transactionRepo.confirmPendingAndApplyBalance).toHaveBeenCalledTimes(1)
     expect(accountRepo.updateBalance).not.toHaveBeenCalled()
   })
 

--- a/api/src/tests/upcoming-transactions.test.ts
+++ b/api/src/tests/upcoming-transactions.test.ts
@@ -104,7 +104,7 @@ describe('upcoming transactions', () => {
         id: 'tx-1',
         account_id: 'account-1',
         amount: 500,
-        date: '2026-07-07',
+        date: '2000-01-01',
         status: 'pending',
       },
     }
@@ -116,6 +116,26 @@ describe('upcoming transactions', () => {
     expect(result.confirmed_at).toEqual(expect.any(Number))
     expect(accounts['account-1'].balance).toBe(1500)
     expect(accountRepo.updateBalance).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects confirming pending transactions dated in the future', async () => {
+    const accounts = { 'account-1': makeAccount() }
+    const transactions: Record<string, Transaction> = {
+      'tx-1': {
+        id: 'tx-1',
+        account_id: 'account-1',
+        amount: 500,
+        date: '2999-01-01',
+        status: 'pending',
+      },
+    }
+    const { service, transactionRepo, accountRepo } = createService(transactions, accounts)
+
+    await expect(service.confirmTransaction('tx-1'))
+      .rejects.toThrow('Cannot confirm a transaction dated in the future')
+
+    expect(transactionRepo.update).not.toHaveBeenCalled()
+    expect(accountRepo.updateBalance).not.toHaveBeenCalled()
   })
 
   it('declines a pending transaction without changing balance', async () => {

--- a/api/src/tests/upcoming-transactions.test.ts
+++ b/api/src/tests/upcoming-transactions.test.ts
@@ -183,6 +183,28 @@ describe('upcoming transactions', () => {
     expect(accountRepo.updateBalance).not.toHaveBeenCalled()
   })
 
+  it('rejects confirmation when the atomic balance application does not complete', async () => {
+    const accounts = { 'account-1': makeAccount() }
+    const transactions: Record<string, Transaction> = {
+      'tx-1': {
+        id: 'tx-1',
+        account_id: 'account-1',
+        amount: 500,
+        date: '2000-01-01',
+        status: 'pending',
+      },
+    }
+    const { service, transactionRepo, accountRepo } = createService(transactions, accounts)
+    transactionRepo.confirmPendingAndApplyBalance.mockResolvedValueOnce(false)
+
+    await expect(service.confirmTransaction('tx-1'))
+      .rejects.toThrow('Transaction is not pending confirmation')
+
+    expect(transactions['tx-1'].status).toBe('pending')
+    expect(accounts['account-1'].balance).toBe(1000)
+    expect(accountRepo.updateBalance).not.toHaveBeenCalled()
+  })
+
   it('rejects confirming pending transactions dated in the future', async () => {
     const accounts = { 'account-1': makeAccount() }
     const transactions: Record<string, Transaction> = {

--- a/api/src/tests/upcoming-transactions.test.ts
+++ b/api/src/tests/upcoming-transactions.test.ts
@@ -64,6 +64,39 @@ describe('upcoming transactions', () => {
     expect(accountRepo.updateBalance).not.toHaveBeenCalled()
   })
 
+  it('rejects linked transfer transactions that would become pending', async () => {
+    const accounts = { 'account-1': makeAccount() }
+    const transactions: Record<string, Transaction> = {}
+    const { service, transactionRepo, accountRepo } = createService(transactions, accounts)
+
+    await expect(service.createTransaction({
+      account_id: 'account-1',
+      amount: -500,
+      date: '2999-01-01',
+      linked_transaction_id: 'linked-tx',
+    })).rejects.toThrow('Linked transfers cannot be pending')
+
+    expect(transactionRepo.create).not.toHaveBeenCalled()
+    expect(accountRepo.updateBalance).not.toHaveBeenCalled()
+  })
+
+  it('rejects explicit pending linked transfer transactions', async () => {
+    const accounts = { 'account-1': makeAccount() }
+    const transactions: Record<string, Transaction> = {}
+    const { service, transactionRepo, accountRepo } = createService(transactions, accounts)
+
+    await expect(service.createTransaction({
+      account_id: 'account-1',
+      amount: -500,
+      date: '2026-07-07',
+      linked_transaction_id: 'linked-tx',
+      status: 'pending',
+    })).rejects.toThrow('Linked transfers cannot be pending')
+
+    expect(transactionRepo.create).not.toHaveBeenCalled()
+    expect(accountRepo.updateBalance).not.toHaveBeenCalled()
+  })
+
   it('confirms a pending transaction and applies it once', async () => {
     const accounts = { 'account-1': makeAccount() }
     const transactions: Record<string, Transaction> = {
@@ -103,6 +136,63 @@ describe('upcoming transactions', () => {
     expect(result.status).toBe('cancelled')
     expect(result.cancelled_at).toEqual(expect.any(Number))
     expect(accounts['account-1'].balance).toBe(1000)
+    expect(accountRepo.updateBalance).not.toHaveBeenCalled()
+  })
+
+  it('rejects declining linked transfer transactions', async () => {
+    const accounts = { 'account-1': makeAccount() }
+    const transactions: Record<string, Transaction> = {
+      'tx-1': {
+        id: 'tx-1',
+        account_id: 'account-1',
+        amount: -500,
+        date: '2026-07-07',
+        linked_transaction_id: 'tx-2',
+        status: 'pending',
+      },
+    }
+    const { service, transactionRepo, accountRepo } = createService(transactions, accounts)
+
+    await expect(service.declineTransaction('tx-1'))
+      .rejects.toThrow('Linked transfers cannot be declined as upcoming transactions')
+
+    expect(transactionRepo.update).not.toHaveBeenCalled()
+    expect(accountRepo.updateBalance).not.toHaveBeenCalled()
+  })
+
+  it('rejects editing linked transfer transactions that are already pending', async () => {
+    const accounts = {
+      'account-1': makeAccount(),
+      'account-2': makeAccount({ id: 'account-2', name: 'Savings' }),
+    }
+    const transactions: Record<string, Transaction> = {
+      'tx-1': {
+        id: 'tx-1',
+        account_id: 'account-1',
+        amount: -500,
+        date: '2026-07-07',
+        linked_transaction_id: 'tx-2',
+        status: 'pending',
+      },
+      'tx-2': {
+        id: 'tx-2',
+        account_id: 'account-2',
+        amount: 500,
+        date: '2026-07-07',
+        linked_transaction_id: 'tx-1',
+        status: 'pending',
+      },
+    }
+    const { service, transactionRepo, accountRepo } = createService(transactions, accounts)
+
+    await expect(service.updateTransaction('tx-1', {
+      amount: 700,
+      amount_to: 700,
+      account_id: 'account-1',
+      to_account_id: 'account-2',
+    })).rejects.toThrow('Linked transfers cannot be pending')
+
+    expect(transactionRepo.update).not.toHaveBeenCalled()
     expect(accountRepo.updateBalance).not.toHaveBeenCalled()
   })
 

--- a/api/src/tests/upcoming-transactions.test.ts
+++ b/api/src/tests/upcoming-transactions.test.ts
@@ -25,6 +25,22 @@ function createService(transactions: Record<string, Transaction>, accounts: Reco
       transactions[id] = { ...transactions[id], ...updates }
     }),
     findUpcoming: vi.fn(async () => Object.values(transactions).filter(tx => tx.status === 'pending')),
+    confirmPendingAndApplyBalance: vi.fn(async (transaction: Transaction, now: number, today: string) => {
+      const current = transactions[transaction.id]
+      if (!current || current.status !== 'pending' || current.linked_transaction_id || current.date > today) {
+        return false
+      }
+
+      current.status = 'posted'
+      current.confirmed_at = now
+      current.cancelled_at = null
+      current.updated_at = now
+      if (accounts[current.account_id]) {
+        accounts[current.account_id].balance += current.amount
+        accounts[current.account_id].updated_at = now
+      }
+      return true
+    }),
   }
 
   const accountRepo = {
@@ -108,14 +124,63 @@ describe('upcoming transactions', () => {
         status: 'pending',
       },
     }
-    const { service, accountRepo } = createService(transactions, accounts)
+    const { service, transactionRepo, accountRepo } = createService(transactions, accounts)
 
     const result = await service.confirmTransaction('tx-1')
 
     expect(result.status).toBe('posted')
     expect(result.confirmed_at).toEqual(expect.any(Number))
     expect(accounts['account-1'].balance).toBe(1500)
-    expect(accountRepo.updateBalance).toHaveBeenCalledTimes(1)
+    expect(transactionRepo.confirmPendingAndApplyBalance).toHaveBeenCalledTimes(1)
+    expect(accountRepo.updateBalance).not.toHaveBeenCalled()
+  })
+
+  it('treats already posted confirmations as idempotent no-ops', async () => {
+    const accounts = { 'account-1': makeAccount({ balance: 1500 }) }
+    const transactions: Record<string, Transaction> = {
+      'tx-1': {
+        id: 'tx-1',
+        account_id: 'account-1',
+        amount: 500,
+        date: '2000-01-01',
+        status: 'posted',
+        confirmed_at: Date.now(),
+      },
+    }
+    const { service, transactionRepo, accountRepo } = createService(transactions, accounts)
+
+    const result = await service.confirmTransaction('tx-1')
+
+    expect(result.status).toBe('posted')
+    expect(accounts['account-1'].balance).toBe(1500)
+    expect(transactionRepo.confirmPendingAndApplyBalance).not.toHaveBeenCalled()
+    expect(accountRepo.updateBalance).not.toHaveBeenCalled()
+  })
+
+  it('does not apply balance when another confirmation already claimed the pending transaction', async () => {
+    const accounts = { 'account-1': makeAccount({ balance: 1500 }) }
+    const transactions: Record<string, Transaction> = {
+      'tx-1': {
+        id: 'tx-1',
+        account_id: 'account-1',
+        amount: 500,
+        date: '2000-01-01',
+        status: 'pending',
+      },
+    }
+    const { service, transactionRepo, accountRepo } = createService(transactions, accounts)
+    transactionRepo.confirmPendingAndApplyBalance.mockImplementationOnce(async () => {
+      transactions['tx-1'].status = 'posted'
+      transactions['tx-1'].confirmed_at = Date.now()
+      return false
+    })
+
+    const result = await service.confirmTransaction('tx-1')
+
+    expect(result.status).toBe('posted')
+    expect(accounts['account-1'].balance).toBe(1500)
+    expect(transactionRepo.confirmPendingAndApplyBalance).toHaveBeenCalledTimes(1)
+    expect(accountRepo.updateBalance).not.toHaveBeenCalled()
   })
 
   it('rejects confirming pending transactions dated in the future', async () => {

--- a/api/src/tests/validators.test.ts
+++ b/api/src/tests/validators.test.ts
@@ -101,6 +101,16 @@ describe('Transaction validators', () => {
     expect(result.success).toBe(true)
   })
 
+  it('accepts uncategorized transactions', () => {
+    const result = CreateTransactionSchema.safeParse({
+      account_id: 'acc-123',
+      amount: -1000,
+      date: '2026-04-01',
+      category_id: null,
+    })
+    expect(result.success).toBe(true)
+  })
+
   it('accepts linked transfer update fields', () => {
     const result = UpdateTransactionSchema.safeParse({
       account_id: 'acc-1',

--- a/api/src/validators/transaction.validator.ts
+++ b/api/src/validators/transaction.validator.ts
@@ -4,7 +4,7 @@ const dateRegex = /^\d{4}-\d{2}-\d{2}$/
 
 export const CreateTransactionSchema = z.object({
   account_id: z.string().min(1, 'account_id is required'),
-  category_id: z.string().optional(),
+  category_id: z.string().nullable().optional(),
   amount: z.number().finite('Amount must be a finite number').refine(n => n !== 0, 'Amount cannot be zero'),
   description: z.string().max(500).optional(),
   date: z.string().regex(dateRegex, 'Date must be YYYY-MM-DD'),

--- a/api/src/validators/transaction.validator.ts
+++ b/api/src/validators/transaction.validator.ts
@@ -11,6 +11,7 @@ export const CreateTransactionSchema = z.object({
   price: z.number().positive().optional(),
   linked_transaction_id: z.string().optional(),
   exclude_from_estimate: z.boolean().optional(),
+  status: z.enum(['posted', 'pending']).optional(),
 })
 
 export const UpdateTransactionSchema = z.object({

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -303,7 +303,7 @@ function App() {
                   <p className="text-[9px] sm:text-xs text-muted-foreground mt-1 sm:mt-2">
                     {investmentError ? investmentError : projectedNetWorth !== null && pendingNetWorthDelta !== 0 ? (
                       <>
-                        Projected{' '}
+                        After all upcoming{' '}
                         <span className={privacyMode === 'hidden' || shouldHideInvestment() ? 'select-none' : ''}>
                           {(privacyMode === 'hidden' || shouldHideInvestment()) && !showNetWorth
                             ? '••••••'
@@ -342,7 +342,7 @@ function App() {
                   <p className="text-[9px] sm:text-xs text-muted-foreground mt-1 sm:mt-2">
                     {pendingCashDelta !== 0 ? (
                       <>
-                        Projected{' '}
+                        After all upcoming{' '}
                         <span className={privacyMode === 'hidden' ? 'select-none' : ''}>
                           {privacyMode === 'hidden'
                             ? '••••••'

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -45,6 +45,7 @@ function App() {
     accounts,
     transactions,
     allTransactions,
+    upcomingTransactions,
     transactionsLoading,
     categories,
     exchangeRates,
@@ -119,7 +120,43 @@ function App() {
       return sum + account.balance / rate
     }, 0)
 
+  const pendingPeriodTransactions = upcomingTransactions.filter(t =>
+    t.date >= dateRange.startDate && t.date <= dateRange.endDate
+  )
+
+  const pendingIncome = pendingPeriodTransactions
+    .filter(t => {
+      const account = accounts.find(a => a.id === t.account_id)
+      const isExcluded = account?.exclude_from_cash_balance && account?.exclude_from_net_worth
+      return t.amount > 0 && !t.linked_transaction_id && account?.type !== 'investment' && !isExcluded
+    })
+    .reduce((sum, t) => sum + convertToMasterCurrency(t.amount, t.account_id), 0)
+
+  const pendingExpenses = pendingPeriodTransactions
+    .filter(t => {
+      const account = accounts.find(a => a.id === t.account_id)
+      const isExcluded = account?.exclude_from_cash_balance && account?.exclude_from_net_worth
+      return t.amount < 0 && !t.linked_transaction_id && account?.type !== 'investment' && !isExcluded
+    })
+    .reduce((sum, t) => sum + Math.abs(convertToMasterCurrency(t.amount, t.account_id)), 0)
+
+  const pendingCashDelta = upcomingTransactions
+    .filter(t => {
+      const account = accounts.find(a => a.id === t.account_id)
+      return account?.type === 'cash' && !(account.exclude_from_cash_balance && account.exclude_from_net_worth)
+    })
+    .reduce((sum, t) => sum + convertToMasterCurrency(t.amount, t.account_id), 0)
+
+  const pendingNetWorthDelta = upcomingTransactions
+    .filter(t => {
+      const account = accounts.find(a => a.id === t.account_id)
+      return account?.type !== 'investment' && !account?.exclude_from_net_worth
+    })
+    .reduce((sum, t) => sum + convertToMasterCurrency(t.amount, t.account_id), 0)
+
   const totalNetWorth = netWorth !== null && !investmentLoading ? netWorth + investmentValue : null
+  const projectedNetWorth = totalNetWorth !== null ? totalNetWorth + pendingNetWorthDelta : null
+  const projectedCashBalance = cashBalance + pendingCashDelta
   const hasInvestmentAccounts = accounts.some(a => a.type === 'investment')
   const showSeparateCashCard = hasInvestmentAccounts
 
@@ -264,7 +301,17 @@ function App() {
                     )}
                   </div>
                   <p className="text-[9px] sm:text-xs text-muted-foreground mt-1 sm:mt-2">
-                    {investmentError ? investmentError : 'Total value'}
+                    {investmentError ? investmentError : projectedNetWorth !== null && pendingNetWorthDelta !== 0 ? (
+                      <>
+                        Projected{' '}
+                        <span className={privacyMode === 'hidden' || shouldHideInvestment() ? 'select-none' : ''}>
+                          {(privacyMode === 'hidden' || shouldHideInvestment()) && !showNetWorth
+                            ? '••••••'
+                            : projectedNetWorth.toLocaleString('hu-HU', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
+                        </span>{' '}
+                        {masterCurrency}
+                      </>
+                    ) : 'Total value'}
                   </p>
                 </div>
               </div>
@@ -293,7 +340,21 @@ function App() {
                     )}
                   </div>
                   <p className="text-[9px] sm:text-xs text-muted-foreground mt-1 sm:mt-2">
-                    {accounts.filter(a => a.type === 'cash').length} account{accounts.filter(a => a.type === 'cash').length !== 1 ? 's' : ''}
+                    {pendingCashDelta !== 0 ? (
+                      <>
+                        Projected{' '}
+                        <span className={privacyMode === 'hidden' ? 'select-none' : ''}>
+                          {privacyMode === 'hidden'
+                            ? '••••••'
+                            : projectedCashBalance.toLocaleString('hu-HU', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
+                        </span>{' '}
+                        {masterCurrency}
+                      </>
+                    ) : (
+                      <>
+                        {accounts.filter(a => a.type === 'cash').length} account{accounts.filter(a => a.type === 'cash').length !== 1 ? 's' : ''}
+                      </>
+                    )}
                   </p>
                 </div>
               )}
@@ -318,7 +379,13 @@ function App() {
                     </>
                   )}
                 </div>
-                <p className="text-[9px] sm:text-xs text-muted-foreground mt-1 sm:mt-2">This period</p>
+                <p className="text-[9px] sm:text-xs text-muted-foreground mt-1 sm:mt-2">
+                  {pendingIncome > 0 ? (
+                    <>
+                      +{privacyMode === 'hidden' ? '••••••' : pendingIncome.toLocaleString('hu-HU', { minimumFractionDigits: 0, maximumFractionDigits: 0 })} {masterCurrency} pending
+                    </>
+                  ) : 'This period'}
+                </p>
               </div>
 
               {/* Expenses Card */}
@@ -342,7 +409,13 @@ function App() {
                     </>
                   )}
                 </div>
-                <p className="text-[9px] sm:text-xs text-muted-foreground mt-1 sm:mt-2">This period</p>
+                <p className="text-[9px] sm:text-xs text-muted-foreground mt-1 sm:mt-2">
+                  {pendingExpenses > 0 ? (
+                    <>
+                      −{privacyMode === 'hidden' ? '••••••' : pendingExpenses.toLocaleString('hu-HU', { minimumFractionDigits: 0, maximumFractionDigits: 0 })} {masterCurrency} pending
+                    </>
+                  ) : 'This period'}
+                </p>
               </div>
             </div>
           )}
@@ -355,6 +428,7 @@ function App() {
               <div className="lg:col-span-8">
                 <TransactionList
                   transactions={transactions}
+                  upcomingTransactions={upcomingTransactions}
                   accounts={accounts}
                   onTransactionAdded={handleDataChange}
                   loading={transactionsLoading}
@@ -372,7 +446,7 @@ function App() {
               </div>
             </div>
           ) : view === 'analytics' ? (
-            <Analytics transactions={allTransactions} categories={categories} accounts={accounts} masterCurrency={masterCurrency} loading={transactionsLoading} />
+            <Analytics transactions={allTransactions} upcomingTransactions={upcomingTransactions} categories={categories} accounts={accounts} masterCurrency={masterCurrency} loading={transactionsLoading} />
           ) : view === 'investments' ? (
             <Investments key={investmentRefreshKey} />
           ) : view === 'recurring' ? (

--- a/client/src/components/analytics-module/Analytics.tsx
+++ b/client/src/components/analytics-module/Analytics.tsx
@@ -21,6 +21,7 @@ import type { Transaction, Category, Account, TimePeriod, SpendingEstimate, Char
 
 type AnalyticsProps = {
   transactions: Transaction[]
+  upcomingTransactions?: Transaction[]
   categories: Category[]
   accounts: Account[]
   masterCurrency?: string
@@ -63,12 +64,14 @@ function AnalyticsSkeleton() {
 
 export function Analytics({
   transactions,
+  upcomingTransactions = [],
   categories,
   accounts,
   masterCurrency = 'HUF',
   loading = false
 }: AnalyticsProps) {
   const [period, setPeriod] = useState<TimePeriod>('month')
+  const [projectionMode, setProjectionMode] = useState<'actual' | 'projected'>('actual')
   const [selectedExpenseCategory, setSelectedExpenseCategory] = useState<string>('all')
   const [selectedIncomeCategory, setSelectedIncomeCategory] = useState<string>('all')
   const [exchangeRates, setExchangeRates] = useState<Record<string, number>>({})
@@ -85,6 +88,13 @@ export function Analytics({
   }
 
   const show = (id: WidgetId) => widgetVisibility[id]
+
+  const transactionsForAnalytics = useMemo(() => {
+    if (projectionMode === 'projected') {
+      return [...transactions, ...upcomingTransactions]
+    }
+    return transactions
+  }, [projectionMode, transactions, upcomingTransactions])
 
   const customDateRange = useMemo(() => {
     if (period === 'month') {
@@ -160,7 +170,7 @@ export function Analytics({
 
   // Filter transactions by period (exclude investment accounts only)
   const filteredTransactions = useMemo(() => {
-    return transactions.filter(tx => {
+    return transactionsForAnalytics.filter(tx => {
       const txDate = new Date(tx.date)
       const account = accounts.find(a => a.id === tx.account_id)
       
@@ -179,7 +189,7 @@ export function Analytics({
           return true
       }
     })
-  }, [transactions, period, accounts, customDateRange])
+  }, [transactionsForAnalytics, period, accounts, customDateRange])
 
   // Calculate totals in master currency
   const { totalIncome, totalExpenses, netFlow } = useMemo(() => {
@@ -257,7 +267,7 @@ export function Analytics({
       return sum + convertToMasterCurrency(acc.balance, acc.id)
     }, 0)
 
-    const sortedTransactions = [...transactions]
+    const sortedTransactions = [...transactionsForAnalytics]
       .filter(tx => cashAccountIds.has(tx.account_id))
       .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
 
@@ -313,14 +323,14 @@ export function Analytics({
       ema = point.balance * k + ema * (1 - k)
       return { ...point, smoothed: ema }
     })
-  }, [transactions, accounts, period, exchangeRates, masterCurrency, customDateRange])
+  }, [transactionsForAnalytics, accounts, period, exchangeRates, masterCurrency, customDateRange])
 
   // Per-account Net Worth Trend data in master currency (exclude investment accounts)
   const perAccountTrendData = useMemo(() => {
     return accounts
       .filter(account => account.type !== 'investment')
       .map(account => {
-        const accountTransactions = transactions.filter(t => {
+        const accountTransactions = transactionsForAnalytics.filter(t => {
           const txDate = new Date(t.date)
           const matchesAccount = t.account_id === account.id
           if (!matchesAccount) return false
@@ -402,7 +412,7 @@ export function Analytics({
         }
       })
       .filter(({ hasTransactions }) => hasTransactions)
-  }, [accounts, transactions, period, exchangeRates, masterCurrency, customDateRange])
+  }, [accounts, transactionsForAnalytics, period, exchangeRates, masterCurrency, customDateRange])
 
   // Get expense categories for filter
   const expenseCategories = useMemo(() => {
@@ -430,7 +440,7 @@ export function Analytics({
         const weekEnd = endOfWeek(weekStart, { weekStartsOn: 1 })
         const weekKey = format(weekStart, 'yyyy-MM-dd')
         
-        const weekIncome = transactions
+        const weekIncome = transactionsForAnalytics
           .filter(tx => {
             const account = accounts.find(a => a.id === tx.account_id)
             if (account?.type === 'investment') return false
@@ -457,7 +467,7 @@ export function Analytics({
     } else {
       const maxMonths = period === 'allTime' ? 100 : 12
       
-      const incomeTransactions = transactions.filter(tx => {
+      const incomeTransactions = transactionsForAnalytics.filter(tx => {
         const account = accounts.find(a => a.id === tx.account_id)
         if (account?.type === 'investment') return false
         if (tx.amount <= 0) return false
@@ -485,7 +495,7 @@ export function Analytics({
         
         if (period === 'year' && !isWithinInterval(monthDate, { start: new Date(customDateRange.startDate), end: new Date(customDateRange.endDate) })) continue
         
-        const monthIncome = transactions
+        const monthIncome = transactionsForAnalytics
           .filter(tx => {
             const account = accounts.find(a => a.id === tx.account_id)
             if (account?.type === 'investment') return false
@@ -506,7 +516,7 @@ export function Analytics({
     }
     
     return data
-  }, [transactions, selectedIncomeCategory, period, customDateRange, accounts, exchangeRates, masterCurrency])
+  }, [transactionsForAnalytics, selectedIncomeCategory, period, customDateRange, accounts, exchangeRates, masterCurrency])
 
   // Expenses comparison data
   const expensesChartData = useMemo((): ChartDataPoint[] => {
@@ -524,7 +534,7 @@ export function Analytics({
         const weekEnd = endOfWeek(weekStart, { weekStartsOn: 1 })
         const weekKey = format(weekStart, 'yyyy-MM-dd')
         
-        const weekExpenses = transactions
+        const weekExpenses = transactionsForAnalytics
           .filter(tx => {
             const account = accounts.find(a => a.id === tx.account_id)
             if (account?.type === 'investment') return false
@@ -551,7 +561,7 @@ export function Analytics({
     } else {
       const maxMonths = period === 'allTime' ? 100 : 12
       
-      const expenseTransactions = transactions.filter(tx => {
+      const expenseTransactions = transactionsForAnalytics.filter(tx => {
         const account = accounts.find(a => a.id === tx.account_id)
         if (account?.type === 'investment') return false
         if (tx.amount >= 0) return false
@@ -579,7 +589,7 @@ export function Analytics({
         
         if (period === 'year' && !isWithinInterval(monthDate, { start: new Date(customDateRange.startDate), end: new Date(customDateRange.endDate) })) continue
         
-        const monthExpenses = transactions
+        const monthExpenses = transactionsForAnalytics
           .filter(tx => {
             const account = accounts.find(a => a.id === tx.account_id)
             if (account?.type === 'investment') return false
@@ -600,7 +610,7 @@ export function Analytics({
     }
     
     return data
-  }, [transactions, selectedExpenseCategory, period, customDateRange, accounts, exchangeRates, masterCurrency])
+  }, [transactionsForAnalytics, selectedExpenseCategory, period, customDateRange, accounts, exchangeRates, masterCurrency])
 
   const periodLabels: Record<TimePeriod, string> = {
     allTime: 'All Time',
@@ -705,6 +715,28 @@ export function Analytics({
               </Button>
             </div>
           )}
+          <div className="flex gap-1 p-1 rounded-xl bg-background/80 border border-border/70 shadow-inner w-full sm:w-auto">
+            <button
+              onClick={() => setProjectionMode('actual')}
+              className={`flex-1 sm:flex-none px-2.5 sm:px-3 py-1.5 text-xs font-medium rounded-lg transition-all whitespace-nowrap ${
+                projectionMode === 'actual'
+                  ? 'bg-primary text-primary-foreground shadow-md'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-secondary/70'
+              }`}
+            >
+              Actual
+            </button>
+            <button
+              onClick={() => setProjectionMode('projected')}
+              className={`flex-1 sm:flex-none px-2.5 sm:px-3 py-1.5 text-xs font-medium rounded-lg transition-all whitespace-nowrap ${
+                projectionMode === 'projected'
+                  ? 'bg-primary text-primary-foreground shadow-md'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-secondary/70'
+              }`}
+            >
+              Projected{upcomingTransactions.length > 0 ? ` (${upcomingTransactions.length})` : ''}
+            </button>
+          </div>
         </div>
       </div>
 
@@ -742,7 +774,7 @@ export function Analytics({
 
             {show('cash-balance-forecast') && isCurrentMonthView && (
               <PredictionChart
-                transactions={transactions}
+                transactions={transactionsForAnalytics}
                 accounts={accounts}
                 masterCurrency={masterCurrency}
                 exchangeRates={exchangeRates}

--- a/client/src/components/analytics-module/types.ts
+++ b/client/src/components/analytics-module/types.ts
@@ -6,6 +6,7 @@ export type Transaction = {
   description?: string
   date: string
   linked_transaction_id?: string
+  status?: 'posted' | 'pending' | 'cancelled'
 }
 
 export type Category = {

--- a/client/src/components/budget-module/Budget.tsx
+++ b/client/src/components/budget-module/Budget.tsx
@@ -42,7 +42,7 @@ type BudgetProps = {
 }
 
 export function Budget({ accounts, categories, transactions, masterCurrency }: BudgetProps) {
-  const { confirm } = useAlert()
+  const { confirm, showAlert } = useAlert()
   const [budgets, setBudgets] = useState<Budget[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -149,6 +149,7 @@ export function Budget({ accounts, categories, transactions, masterCurrency }: B
     account_ids?: string[]
     category_ids?: string[]
   }) => {
+    const wasEditing = !!editingBudget
     const payloadWithCurrency = {
       ...payload,
       currency: masterCurrency
@@ -177,6 +178,10 @@ export function Budget({ accounts, categories, transactions, masterCurrency }: B
 
     await fetchBudgets()
     setEditingBudget(null)
+    showAlert({
+      type: 'success',
+      message: wasEditing ? 'Budget updated' : 'Budget created'
+    })
   }
 
   const handleEdit = (budget: Budget) => {
@@ -200,8 +205,11 @@ export function Budget({ accounts, categories, transactions, masterCurrency }: B
         throw new Error(data?.error || 'Failed to delete budget')
       }
       await fetchBudgets()
+      showAlert({ type: 'success', message: 'Budget deleted' })
     } catch (err: any) {
-      setError(err?.message || 'Failed to delete budget')
+      const message = err?.message || 'Failed to delete budget'
+      setError(message)
+      showAlert({ type: 'error', message })
     } finally {
       setDeletingId(null)
     }

--- a/client/src/components/budget-module/BudgetFormModal.tsx
+++ b/client/src/components/budget-module/BudgetFormModal.tsx
@@ -3,6 +3,7 @@ import { Modal } from '../common/modal'
 import { Input } from '../common/input'
 import { Select } from '../common/select'
 import { Button } from '../common/button'
+import { useAlert } from '../../context/AlertContext'
 import type { Budget, BudgetFormData, BudgetAccountScope, BudgetCategoryScope, BudgetPeriod } from './types'
 
 type Account = {
@@ -64,6 +65,7 @@ export function BudgetFormModal({
   initialData,
   masterCurrency
 }: BudgetFormModalProps) {
+  const { showAlert } = useAlert()
   const currentYear = new Date().getFullYear()
   const [form, setForm] = useState<BudgetFormData>(() => emptyForm(currentYear))
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -138,7 +140,9 @@ export function BudgetFormModal({
       })
       onClose()
     } catch (err: any) {
-      setError(err?.message || 'Failed to save budget.')
+      const message = err?.message || 'Failed to save budget.'
+      setError(message)
+      showAlert({ type: 'error', message })
     } finally {
       setIsSubmitting(false)
     }

--- a/client/src/components/dashboard-module/AccountList.tsx
+++ b/client/src/components/dashboard-module/AccountList.tsx
@@ -268,6 +268,7 @@ export function AccountList({ accounts, onAccountAdded, loading }: { accounts: A
     
     setIsSubmitting(true)
     try {
+      const wasEditing = !!editingId
       const balanceValue = formData.balance.replace(/\s/g, '').trim()
       const payload: any = {
         name: formData.name,
@@ -317,9 +318,16 @@ export function AccountList({ accounts, onAccountAdded, loading }: { accounts: A
       setIsAdding(false)
       resetForm()
       onAccountAdded()
+      showAlert({
+        type: 'success',
+        message: wasEditing ? 'Account updated' : 'Account created'
+      })
     } catch (error) {
       console.error('Failed to save account', error)
-      showAlert({ type: 'error', message: 'Failed to save account. Please try again.' })
+      showAlert({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Failed to save account. Please try again.'
+      })
     } finally {
       setIsSubmitting(false)
     }
@@ -367,8 +375,13 @@ export function AccountList({ accounts, onAccountAdded, loading }: { accounts: A
     try {
       await apiFetch(`${API_BASE_URL}/accounts/${id}`, { method: 'DELETE' })
       onAccountAdded()
+      showAlert({ type: 'success', message: 'Account deleted' })
     } catch (error) {
       console.error('Failed to delete account', error)
+      showAlert({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Failed to delete account. Please try again.'
+      })
     } finally {
       setDeletingId(null)
     }
@@ -381,7 +394,8 @@ export function AccountList({ accounts, onAccountAdded, loading }: { accounts: A
   }
 
   const handleLockToggle = async (accountId: string) => {
-    if (isLocked(accountId)) {
+    const wasLocked = isLocked(accountId)
+    if (wasLocked) {
       const confirmed = await confirm({
         title: 'Unlock Account',
         message: 'Are you sure you want to unlock this account? You will be able to edit, delete, and add transactions again.',
@@ -392,12 +406,22 @@ export function AccountList({ accounts, onAccountAdded, loading }: { accounts: A
     }
     setLockingId(accountId)
     try {
-      if (isLocked(accountId)) {
+      if (wasLocked) {
         await apiFetch(`${API_BASE_URL}/accounts/${accountId}/unlock`, { method: 'PATCH' })
       } else {
         await apiFetch(`${API_BASE_URL}/accounts/${accountId}/lock`, { method: 'PATCH' })
       }
       onAccountAdded()
+      showAlert({
+        type: 'success',
+        message: wasLocked ? 'Account unlocked' : 'Account locked'
+      })
+    } catch (error) {
+      console.error('Failed to update account lock state', error)
+      showAlert({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Failed to update account lock state'
+      })
     } finally {
       setLockingId(null)
     }
@@ -448,7 +472,7 @@ export function AccountList({ accounts, onAccountAdded, loading }: { accounts: A
       console.error('Failed to update account exclusions', error)
       showAlert({
         type: 'error',
-        message: 'Failed to update account exclusion settings'
+        message: error instanceof Error ? error.message : 'Failed to update account exclusion settings'
       })
     }
   }
@@ -493,7 +517,7 @@ export function AccountList({ accounts, onAccountAdded, loading }: { accounts: A
       console.error('Failed to save account with adjustment', error)
       showAlert({
         type: 'error',
-        message: 'Failed to save account changes'
+        message: error instanceof Error ? error.message : 'Failed to save account changes'
       })
     }
   }
@@ -528,7 +552,7 @@ export function AccountList({ accounts, onAccountAdded, loading }: { accounts: A
       console.error('Failed to save account with split transactions', error)
       showAlert({
         type: 'error',
-        message: 'Failed to save account changes'
+        message: error instanceof Error ? error.message : 'Failed to save account changes'
       })
     }
   }

--- a/client/src/components/dashboard-module/BulkTransactionModal.tsx
+++ b/client/src/components/dashboard-module/BulkTransactionModal.tsx
@@ -5,6 +5,7 @@ import { Input } from '../common/input'
 import { Label } from '../common/label'
 import { Select } from '../common/select'
 import { Plus, Trash2, AlertCircle, Percent } from 'lucide-react'
+import { useAlert } from '../../context/AlertContext'
 
 type Category = {
   id: string
@@ -50,6 +51,7 @@ export function BulkTransactionModal({
   defaultAccountId = '',
   defaultDate = new Date().toISOString().split('T')[0]
 }: BulkTransactionModalProps) {
+  const { showAlert } = useAlert()
   const [totalAmount, setTotalAmount] = useState('')
   const [transactionType, setTransactionType] = useState<'expense' | 'income'>('expense')
   const [transactions, setTransactions] = useState<BulkTransaction[]>([])
@@ -141,6 +143,10 @@ export function BulkTransactionModal({
       onClose()
     } catch (error) {
       console.error('Failed to create bulk transactions', error)
+      showAlert({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Failed to create bulk transactions'
+      })
     } finally {
       setIsSubmitting(false)
     }

--- a/client/src/components/dashboard-module/RecurringTransactions.tsx
+++ b/client/src/components/dashboard-module/RecurringTransactions.tsx
@@ -180,6 +180,7 @@ export function RecurringTransactions({
         payload.day_of_month = dayOfMonth
       } else {
         showAlert({ type: 'error', message: 'Please enter a valid day of month (1-31)' })
+        setIsSubmitting(false)
         return
       }
       
@@ -225,37 +226,32 @@ export function RecurringTransactions({
 
     try {
       if (editingId) {
-        const res = await apiFetch(`${API_BASE_URL}/recurring-schedules/${editingId}`, {
+        await apiFetch(`${API_BASE_URL}/recurring-schedules/${editingId}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
         })
-        if (res.ok) {
-          showAlert({ type: 'success', message: 'Recurring schedule updated successfully' })
-          await fetchSchedules()
-          resetForm()
-        } else {
-          const error = await res.json()
-          showAlert({ type: 'error', message: error.error || 'Failed to update recurring schedule' })
-        }
+        showAlert({ type: 'success', message: 'Recurring schedule updated successfully' })
+        await fetchSchedules()
+        resetForm()
       } else {
-        const res = await apiFetch(`${API_BASE_URL}/recurring-schedules`, {
+        await apiFetch(`${API_BASE_URL}/recurring-schedules`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
         })
-        if (res.ok) {
-          showAlert({ type: 'success', message: 'Recurring schedule created successfully' })
-          await fetchSchedules()
-          resetForm()
-        } else {
-          const error = await res.json()
-          showAlert({ type: 'error', message: error.error || 'Failed to create recurring schedule' })
-        }
+        showAlert({ type: 'success', message: 'Recurring schedule created successfully' })
+        await fetchSchedules()
+        resetForm()
       }
     } catch (error) {
-      showAlert({ type: 'error', message: 'An error occurred' })
       console.error(error)
+      showAlert({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Failed to save recurring schedule'
+      })
+    } finally {
+      setIsSubmitting(false)
     }
   }
 
@@ -301,18 +297,17 @@ export function RecurringTransactions({
 
     setDeletingId(id)
     try {
-      const res = await apiFetch(`${API_BASE_URL}/recurring-schedules/${id}`, {
+      await apiFetch(`${API_BASE_URL}/recurring-schedules/${id}`, {
         method: 'DELETE'
       })
-      if (res.ok) {
-        showAlert({ type: 'success', message: 'Recurring schedule deleted successfully' })
-        await fetchSchedules()
-      } else {
-        showAlert({ type: 'error', message: 'Failed to delete recurring schedule' })
-      }
+      showAlert({ type: 'success', message: 'Recurring schedule deleted successfully' })
+      await fetchSchedules()
     } catch (error) {
-      showAlert({ type: 'error', message: 'An error occurred' })
       console.error(error)
+      showAlert({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Failed to delete recurring schedule'
+      })
     } finally {
       setDeletingId(null)
     }
@@ -321,18 +316,19 @@ export function RecurringTransactions({
   const toggleActive = async (schedule: RecurringSchedule) => {
     setTogglingId(schedule.id)
     try {
-      const res = await apiFetch(`${API_BASE_URL}/recurring-schedules/${schedule.id}`, {
+      await apiFetch(`${API_BASE_URL}/recurring-schedules/${schedule.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ is_active: !schedule.is_active })
       })
-      if (res.ok) {
-        showAlert({ type: 'success', message: `Recurring schedule ${!schedule.is_active ? 'activated' : 'deactivated'}` })
-        await fetchSchedules()
-      }
+      showAlert({ type: 'success', message: `Recurring schedule ${!schedule.is_active ? 'activated' : 'deactivated'}` })
+      await fetchSchedules()
     } catch (error) {
-      showAlert({ type: 'error', message: 'An error occurred' })
       console.error(error)
+      showAlert({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Failed to update recurring schedule'
+      })
     } finally {
       setTogglingId(null)
     }

--- a/client/src/components/dashboard-module/TransactionList.tsx
+++ b/client/src/components/dashboard-module/TransactionList.tsx
@@ -121,7 +121,7 @@ export function TransactionList({
   const { confirm, showAlert } = useAlert()
   const { privacyMode, shouldHideInvestment } = usePrivacy()
   const isLocked = (accountId: string) => accounts.find(a => a.id === accountId)?.is_locked ?? false
-  const today = new Date().toISOString().split('T')[0]
+  const today = format(new Date(), 'yyyy-MM-dd')
   const isUpcomingForm = formData.type !== 'transfer' && formData.date > today
   const allKnownTransactions = [...transactions, ...upcomingTransactions]
 

--- a/client/src/components/dashboard-module/TransactionList.tsx
+++ b/client/src/components/dashboard-module/TransactionList.tsx
@@ -5,7 +5,7 @@ import { Label } from '../common/label'
 import { Select } from '../common/select'
 import { Card, CardContent, CardHeader, CardTitle } from '../common/card'
 import { Modal } from '../common/modal'
-import { Plus, X, ArrowDownLeft, ArrowUpRight, Receipt, Pencil, Trash2, Check, ArrowRightLeft, ChevronLeft, ChevronRight, ChevronDown, Calendar, Layers, Search } from 'lucide-react'
+import { Plus, X, ArrowDownLeft, ArrowUpRight, Receipt, Pencil, Trash2, Check, ArrowRightLeft, ChevronLeft, ChevronRight, ChevronDown, Calendar, Layers, Search, Clock, CircleCheck, CircleX, AlertCircle } from 'lucide-react'
 import { format, addMonths, subMonths, startOfMonth, endOfMonth, addDays, differenceInDays } from 'date-fns'
 import { API_BASE_URL, apiFetch } from '../../config'
 import { usePrivacy } from '../../context/PrivacyContext'
@@ -23,6 +23,11 @@ type Transaction = {
   date: string
   linked_transaction_id?: string
   exclude_from_estimate?: boolean
+  status?: 'posted' | 'pending' | 'cancelled'
+  confirmed_at?: number | null
+  cancelled_at?: number | null
+  created_at?: number | null
+  updated_at?: number | null
 }
 
 type Account = {
@@ -62,6 +67,7 @@ const STORAGE_KEYS = {
 
 export function TransactionList({ 
   transactions, 
+  upcomingTransactions,
   accounts, 
   onTransactionAdded,
   loading,
@@ -71,6 +77,7 @@ export function TransactionList({
   onMonthChange
 }: { 
   transactions: Transaction[], 
+  upcomingTransactions: Transaction[],
   accounts: Account[],
   onTransactionAdded: () => void,
   loading?: boolean,
@@ -108,11 +115,15 @@ export function TransactionList({
   const [searchQuery, setSearchQuery] = useState<string>('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [pendingActionId, setPendingActionId] = useState<string | null>(null)
   const [isAccountOpen, setIsAccountOpen] = useState(false)
   
   const { confirm, showAlert } = useAlert()
   const { privacyMode, shouldHideInvestment } = usePrivacy()
   const isLocked = (accountId: string) => accounts.find(a => a.id === accountId)?.is_locked ?? false
+  const today = new Date().toISOString().split('T')[0]
+  const isUpcomingForm = formData.type !== 'transfer' && formData.date > today
+  const allKnownTransactions = [...transactions, ...upcomingTransactions]
 
   // Reset showAllTransactions when filter, sort, search, or date range changes
   useEffect(() => {
@@ -539,7 +550,7 @@ export function TransactionList({
     
     // For transfers, also check if the linked account is locked
     if (tx.linked_transaction_id) {
-      const linkedTx = transactions.find(t => t.id === tx.linked_transaction_id)
+      const linkedTx = allKnownTransactions.find(t => t.id === tx.linked_transaction_id)
       if (linkedTx && isLocked(linkedTx.account_id)) {
         return
       }
@@ -554,7 +565,7 @@ export function TransactionList({
     }
     
     const relatedTx = (tx as Transaction & { relatedTx?: Transaction }).relatedTx
-      || (tx.linked_transaction_id ? transactions.find(t => t.id === tx.linked_transaction_id) : undefined)
+      || (tx.linked_transaction_id ? allKnownTransactions.find(t => t.id === tx.linked_transaction_id) : undefined)
 
     if (tx.linked_transaction_id && relatedTx) {
       const outgoing = tx.amount < 0 ? tx : relatedTx
@@ -612,7 +623,7 @@ export function TransactionList({
 
   const handleDelete = async (id: string) => {
     // Find the transaction first to check if account is locked
-    const tx = transactions.find(t => t.id === id)
+    const tx = allKnownTransactions.find(t => t.id === id)
     if (!tx) return
     
     // Check if the account is locked
@@ -622,7 +633,7 @@ export function TransactionList({
     
     // For transfers, also check if the linked account is locked
     if (tx.linked_transaction_id) {
-      const linkedTx = transactions.find(t => t.id === tx.linked_transaction_id)
+      const linkedTx = allKnownTransactions.find(t => t.id === tx.linked_transaction_id)
       if (linkedTx && isLocked(linkedTx.account_id)) {
         return
       }
@@ -640,7 +651,7 @@ export function TransactionList({
     setDeletingId(id)
     try {
       // Find the transaction to determine if it's an investment transaction
-      const tx = transactions.find(t => t.id === id)
+      const tx = allKnownTransactions.find(t => t.id === id)
       const account = accounts.find(a => a.id === tx?.account_id)
       
       // If it's an investment account and has quantity data, it's from investment_transactions table
@@ -657,6 +668,61 @@ export function TransactionList({
       console.error('Failed to delete transaction', error)
     } finally {
       setDeletingId(null)
+    }
+  }
+
+  const handleConfirmUpcoming = async (id: string) => {
+    if (pendingActionId) return
+
+    setPendingActionId(id)
+    try {
+      const res = await apiFetch(`${API_BASE_URL}/transactions/${id}/confirm`, {
+        method: 'POST'
+      })
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error || 'Failed to confirm transaction')
+      }
+
+      onTransactionAdded()
+    } catch (error) {
+      console.error('Failed to confirm upcoming transaction', error)
+      showAlert({ type: 'error', message: 'Failed to confirm transaction. Please try again.' })
+    } finally {
+      setPendingActionId(null)
+    }
+  }
+
+  const handleDeclineUpcoming = async (id: string) => {
+    if (pendingActionId) return
+
+    const confirmed = await confirm({
+      title: 'Decline Transaction',
+      message: 'Decline this upcoming transaction? It will not affect your balance.',
+      confirmText: 'Decline',
+      cancelText: 'Cancel'
+    })
+
+    if (!confirmed) return
+
+    setPendingActionId(id)
+    try {
+      const res = await apiFetch(`${API_BASE_URL}/transactions/${id}/decline`, {
+        method: 'POST'
+      })
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error || 'Failed to decline transaction')
+      }
+
+      onTransactionAdded()
+    } catch (error) {
+      console.error('Failed to decline upcoming transaction', error)
+      showAlert({ type: 'error', message: 'Failed to decline transaction. Please try again.' })
+    } finally {
+      setPendingActionId(null)
     }
   }
 
@@ -750,7 +816,13 @@ export function TransactionList({
     return catMatch && matchesSearch(tx)
   }
 
-  const totalFilteredCount = transactions.filter(applyFilters).length
+  const pendingFilteredTransactions = upcomingTransactions
+    .filter(applyFilters)
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+
+  const readyTransactions = pendingFilteredTransactions.filter(tx => tx.date <= today)
+  const futureTransactions = pendingFilteredTransactions.filter(tx => tx.date > today)
+  const totalFilteredCount = transactions.filter(applyFilters).length + pendingFilteredTransactions.length
 
   // Helper to process transactions and merge transfers
   const processTransactions = (txs: Transaction[]) => {
@@ -785,6 +857,122 @@ export function TransactionList({
     return processed
   }
 
+  const renderPendingTransaction = (tx: Transaction, ready: boolean) => {
+    const daysFromToday = differenceInDays(new Date(tx.date), new Date(today))
+    const account = accounts.find(a => a.id === tx.account_id)
+    const isInvestmentTx = account?.type === 'investment'
+    const shouldHide = privacyMode === 'hidden' || (isInvestmentTx && shouldHideInvestment())
+    const locked = isLocked(tx.account_id)
+
+    const statusLabel = ready
+      ? daysFromToday < 0
+        ? `${Math.abs(daysFromToday)} day${Math.abs(daysFromToday) === 1 ? '' : 's'} late`
+        : 'Ready today'
+      : `Expected ${format(new Date(tx.date), new Date(tx.date).getFullYear() === new Date().getFullYear() ? 'MMM d' : 'MMM d, yyyy')}`
+
+    return (
+      <div
+        key={tx.id}
+        className={`group flex items-center justify-between p-2 sm:p-3 rounded-lg sm:rounded-xl border transition-all duration-200 ${
+          ready
+            ? 'border-success/20 bg-success/5 hover:bg-success/10'
+            : 'border-primary/15 bg-primary/5 hover:bg-primary/10'
+        }`}
+        onClick={() => setActiveTxId(activeTxId === tx.id ? null : tx.id)}
+      >
+        <div className="flex items-center gap-2 sm:gap-3 min-w-0" onClick={(e) => e.stopPropagation()}>
+          <div className={`h-8 w-8 sm:h-10 sm:w-10 rounded-lg sm:rounded-xl flex items-center justify-center flex-shrink-0 ${
+            ready ? 'bg-success/10 text-success' : 'bg-primary/10 text-primary'
+          }`}>
+            {ready ? <AlertCircle className="h-4 w-4 sm:h-5 sm:w-5" /> : <Clock className="h-4 w-4 sm:h-5 sm:w-5" />}
+          </div>
+          <div className="min-w-0">
+            <p className="font-medium text-xs sm:text-sm truncate">
+              {tx.description || getCategoryName(tx.category_id)}
+            </p>
+            <div className="flex items-center gap-1.5 sm:gap-2 text-[10px] sm:text-xs text-muted-foreground">
+              <span className={ready ? 'text-success font-medium' : 'text-primary font-medium'}>{statusLabel}</span>
+              <span>•</span>
+              <span className="truncate">{getAccountName(tx.account_id)}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col items-end gap-0.5 flex-shrink-0">
+          <div className={`font-bold text-xs sm:text-sm ${tx.amount >= 0 ? 'text-success' : 'text-destructive'} ${shouldHide ? 'select-none' : ''}`}>
+            {shouldHide ? '••••••' : (
+              <>
+                {tx.amount >= 0 ? '+' : '-'}{Math.abs(tx.amount).toLocaleString('hu-HU', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} {getAccountCurrency(tx.account_id)}
+              </>
+            )}
+          </div>
+          <div className={`flex gap-1 transition-opacity ${activeTxId === tx.id ? 'opacity-100' : 'opacity-0 md:group-hover:opacity-100'}`}>
+            {!locked && (
+              <>
+                {ready && (
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-7 w-7 sm:h-8 sm:w-8 text-success hover:text-success"
+                    disabled={pendingActionId === tx.id}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleConfirmUpcoming(tx.id)
+                    }}
+                    title="Confirm transaction"
+                  >
+                    <CircleCheck className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
+                  </Button>
+                )}
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-7 w-7 sm:h-8 sm:w-8"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleEdit(tx)
+                  }}
+                  title="Edit upcoming transaction"
+                >
+                  <Pencil className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
+                </Button>
+                {ready ? (
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-7 w-7 sm:h-8 sm:w-8 text-destructive hover:text-destructive"
+                    disabled={pendingActionId === tx.id}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleDeclineUpcoming(tx.id)
+                    }}
+                    title="Decline transaction"
+                  >
+                    <CircleX className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
+                  </Button>
+                ) : (
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-7 w-7 sm:h-8 sm:w-8 text-destructive hover:text-destructive"
+                    disabled={deletingId === tx.id}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleDelete(tx.id)
+                    }}
+                    title="Delete upcoming transaction"
+                  >
+                    <Trash2 className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
+                  </Button>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <Card>
       <CardHeader className="pb-3 sm:pb-4">
@@ -796,7 +984,9 @@ export function TransactionList({
               </div>
               <div>
                 <CardTitle className="text-sm sm:text-base">Transactions</CardTitle>
-                <p className="text-[10px] sm:text-xs text-muted-foreground">{transactions.length} total</p>
+                <p className="text-[10px] sm:text-xs text-muted-foreground">
+                  {transactions.length} posted{upcomingTransactions.length > 0 ? ` • ${upcomingTransactions.length} pending` : ''}
+                </p>
               </div>
             </div>
             
@@ -1353,6 +1543,9 @@ export function TransactionList({
                       required
                       className="w-full min-w-0"
                     />
+                    {isUpcomingForm && (
+                      <p className="text-[11px] text-primary">This will be saved as an upcoming transaction.</p>
+                    )}
                   </div>
                   <div className="col-span-2 space-y-2">
                     <Label htmlFor="description">Description</Label>
@@ -1381,7 +1574,7 @@ export function TransactionList({
                 </div>
                 <Button type="submit" className="w-full" variant={formData.type === 'income' ? 'success' : 'default'} disabled={isSubmitting}>
                   {editingId ? <Check className="h-4 w-4 mr-2" /> : <Plus className="h-4 w-4 mr-2" />}
-                  {isSubmitting ? 'Saving...' : (editingId ? 'Save Changes' : `Add ${formData.type === 'income' ? 'Income' : 'Expense'}`)}
+                  {isSubmitting ? 'Saving...' : (editingId ? 'Save Changes' : isUpcomingForm ? 'Save Upcoming' : `Add ${formData.type === 'income' ? 'Income' : 'Expense'}`)}
                 </Button>
               </>
             )}
@@ -1390,6 +1583,38 @@ export function TransactionList({
 
       <CardContent className="space-y-3 sm:space-y-4">
         <div className="space-y-3 sm:space-y-4">
+          {(readyTransactions.length > 0 || futureTransactions.length > 0) && (
+            <div className="space-y-3">
+              {readyTransactions.length > 0 && (
+                <div className="space-y-1.5">
+                  <div className="flex items-center gap-1.5 sm:gap-2">
+                    <div className="text-[10px] sm:text-xs font-medium text-success">
+                      Ready to confirm
+                    </div>
+                    <div className="flex-1 h-px bg-success/20" />
+                  </div>
+                  <div className="space-y-1">
+                    {readyTransactions.map(tx => renderPendingTransaction(tx, true))}
+                  </div>
+                </div>
+              )}
+
+              {futureTransactions.length > 0 && (
+                <div className="space-y-1.5">
+                  <div className="flex items-center gap-1.5 sm:gap-2">
+                    <div className="text-[10px] sm:text-xs font-medium text-primary">
+                      Upcoming
+                    </div>
+                    <div className="flex-1 h-px bg-primary/20" />
+                  </div>
+                  <div className="space-y-1">
+                    {futureTransactions.map(tx => renderPendingTransaction(tx, false))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
           {sortOrder === 'date' ? (
             // Date-based grouping
             (() => {
@@ -1710,7 +1935,7 @@ export function TransactionList({
             })()
           )}
           
-          {loading && transactions.length === 0 && (
+          {loading && transactions.length === 0 && upcomingTransactions.length === 0 && (
             <div className="space-y-2">
               {[...Array(6)].map((_, i) => (
                 <div key={i} className="flex items-center gap-3 p-2 sm:p-3 rounded-xl">
@@ -1725,7 +1950,7 @@ export function TransactionList({
             </div>
           )}
 
-          {transactions.length === 0 && !isAdding && !loading && (
+          {transactions.length === 0 && upcomingTransactions.length === 0 && !isAdding && !loading && (
             <div className="text-center py-12">
               <div className="h-12 w-12 rounded-full bg-secondary/50 flex items-center justify-center mx-auto mb-3">
                 <Receipt className="h-6 w-6 text-muted-foreground" />
@@ -1735,7 +1960,7 @@ export function TransactionList({
             </div>
           )}
 
-          {transactions.length > 0 && totalFilteredCount === 0 && !isAdding && !loading && (
+          {(transactions.length > 0 || upcomingTransactions.length > 0) && totalFilteredCount === 0 && !isAdding && !loading && (
             <div className="text-center py-12">
               <div className="h-12 w-12 rounded-full bg-secondary/50 flex items-center justify-center mx-auto mb-3">
                 <Search className="h-6 w-6 text-muted-foreground" />

--- a/client/src/components/dashboard-module/TransactionList.tsx
+++ b/client/src/components/dashboard-module/TransactionList.tsx
@@ -54,7 +54,23 @@ const ALL_TIME_RANGE = { startDate: '1900-01-01', endDate: '2100-12-31' }
 const isAllTimeRange = (r: { startDate: string; endDate: string }) =>
   r.startDate === '1900-01-01' && r.endDate === '2100-12-31'
 const DISPLAY_LIMIT = 7
+const RECENT_TRANSACTION_MS = 10 * 60 * 1000
+const UPDATED_BADGE_GRACE_MS = 1000
 const getLocalDateString = () => format(new Date(), 'yyyy-MM-dd')
+
+const getRecentTransactionLabel = (tx: Transaction, now: number) => {
+  const createdAt = tx.created_at || 0
+  const updatedAt = tx.updated_at || 0
+  const isRecentlyCreated = createdAt > 0 && now >= createdAt && now - createdAt <= RECENT_TRANSACTION_MS
+  const isRecentlyUpdated = updatedAt > 0
+    && now >= updatedAt
+    && now - updatedAt <= RECENT_TRANSACTION_MS
+    && (!createdAt || updatedAt > createdAt + UPDATED_BADGE_GRACE_MS)
+
+  if (isRecentlyUpdated) return 'Updated'
+  if (isRecentlyCreated) return 'New'
+  return null
+}
 
 // LocalStorage keys for remembering last used values
 const STORAGE_KEYS = {
@@ -118,6 +134,7 @@ export function TransactionList({
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const [pendingActionId, setPendingActionId] = useState<string | null>(null)
   const [isAccountOpen, setIsAccountOpen] = useState(false)
+  const [badgeNow, setBadgeNow] = useState(() => Date.now())
   
   const { confirm, showAlert } = useAlert()
   const { privacyMode, shouldHideInvestment } = usePrivacy()
@@ -130,6 +147,11 @@ export function TransactionList({
   useEffect(() => {
     setShowAllTransactions(false)
   }, [categoryFilter, sortOrder, searchQuery, dateRange])
+
+  useEffect(() => {
+    const interval = window.setInterval(() => setBadgeNow(Date.now()), 30000)
+    return () => window.clearInterval(interval)
+  }, [])
 
   useEffect(() => {
     apiFetch(`${API_BASE_URL}/categories`)
@@ -444,6 +466,9 @@ export function TransactionList({
     setIsSubmitting(true)
     try {
       const amount = parseFloat(formData.amount.replace(/\s/g, ''))
+      const wasEditing = !!editingId
+      const savedType = formData.type
+      const savedAsUpcoming = isUpcomingForm
 
       if (formData.type === 'transfer') {
         // Handle transfer
@@ -535,9 +560,22 @@ export function TransactionList({
       setIsAdding(false)
       resetForm()
       onTransactionAdded()
+      showAlert({
+        type: 'success',
+        message: wasEditing
+          ? `${savedType === 'transfer' ? 'Transfer' : 'Transaction'} updated`
+          : savedType === 'transfer'
+            ? 'Transfer created'
+            : savedAsUpcoming
+              ? 'Upcoming transaction saved'
+              : 'Transaction created'
+      })
     } catch (error) {
       console.error('Failed to save transaction', error)
-      showAlert({ type: 'error', message: 'Failed to save transaction. Please try again.' })
+      showAlert({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Failed to save transaction. Please try again.'
+      })
     } finally {
       setIsSubmitting(false)
     }
@@ -665,8 +703,13 @@ export function TransactionList({
       }
       
       onTransactionAdded()
+      showAlert({ type: 'success', message: 'Transaction deleted' })
     } catch (error) {
       console.error('Failed to delete transaction', error)
+      showAlert({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Failed to delete transaction. Please try again.'
+      })
     } finally {
       setDeletingId(null)
     }
@@ -687,9 +730,13 @@ export function TransactionList({
       }
 
       onTransactionAdded()
+      showAlert({ type: 'success', message: 'Upcoming transaction confirmed' })
     } catch (error) {
       console.error('Failed to confirm upcoming transaction', error)
-      showAlert({ type: 'error', message: 'Failed to confirm transaction. Please try again.' })
+      showAlert({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Failed to confirm transaction. Please try again.'
+      })
     } finally {
       setPendingActionId(null)
     }
@@ -719,9 +766,13 @@ export function TransactionList({
       }
 
       onTransactionAdded()
+      showAlert({ type: 'success', message: 'Upcoming transaction declined' })
     } catch (error) {
       console.error('Failed to decline upcoming transaction', error)
-      showAlert({ type: 'error', message: 'Failed to decline transaction. Please try again.' })
+      showAlert({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Failed to decline transaction. Please try again.'
+      })
     } finally {
       setPendingActionId(null)
     }
@@ -755,6 +806,10 @@ export function TransactionList({
     
     setShowBulkModal(false)
     onTransactionAdded()
+    showAlert({
+      type: 'success',
+      message: `${bulkTransactions.length} transaction${bulkTransactions.length === 1 ? '' : 's'} created`
+    })
   }
 
   const matchesSearch = (tx: Transaction): boolean => {
@@ -858,6 +913,17 @@ export function TransactionList({
     return processed
   }
 
+  const renderRecentBadge = (tx: Transaction) => {
+    const recentLabel = getRecentTransactionLabel(tx, badgeNow)
+    if (!recentLabel) return null
+
+    return (
+      <span className="flex-shrink-0 rounded border border-primary/20 bg-primary/10 px-1 py-0.5 text-[9px] font-semibold uppercase leading-none text-primary">
+        {recentLabel}
+      </span>
+    )
+  }
+
   const renderPendingTransaction = (tx: Transaction, ready: boolean) => {
     const daysFromToday = differenceInDays(new Date(tx.date), new Date(today))
     const account = accounts.find(a => a.id === tx.account_id)
@@ -888,8 +954,9 @@ export function TransactionList({
             {ready ? <AlertCircle className="h-4 w-4 sm:h-5 sm:w-5" /> : <Clock className="h-4 w-4 sm:h-5 sm:w-5" />}
           </div>
           <div className="min-w-0">
-            <p className="font-medium text-xs sm:text-sm truncate">
-              {tx.description || getCategoryName(tx.category_id)}
+            <p className="font-medium text-xs sm:text-sm flex items-center gap-1.5 min-w-0">
+              <span className="truncate">{tx.description || getCategoryName(tx.category_id)}</span>
+              {renderRecentBadge(tx)}
             </p>
             <div className="flex items-center gap-1.5 sm:gap-2 text-[10px] sm:text-xs text-muted-foreground">
               <span className={ready ? 'text-success font-medium' : 'text-primary font-medium'}>{statusLabel}</span>
@@ -1665,26 +1732,29 @@ export function TransactionList({
                       className="group flex items-center justify-between p-2 sm:p-3 rounded-lg sm:rounded-xl hover:bg-secondary/30 transition-all duration-200"
                       onClick={() => setActiveTxId(activeTxId === tx.id ? null : tx.id)}
                     >
-                      <div className="flex items-center gap-2 sm:gap-3" onClick={(e) => e.stopPropagation()}>
+                      <div className="flex items-center gap-2 sm:gap-3 min-w-0" onClick={(e) => e.stopPropagation()}>
                         <div className={`h-8 w-8 sm:h-10 sm:w-10 rounded-lg sm:rounded-xl flex items-center justify-center text-base sm:text-lg ${
                           isTransfer ? 'bg-blue-500/10 text-blue-500' :
                           tx.amount >= 0 ? 'bg-success/10' : 'bg-secondary'
                         }`}>
                           {isTransfer ? <ArrowRightLeft className="h-4 w-4 sm:h-5 sm:w-5" /> : getCategoryIcon(tx.category_id)}
                         </div>
-                        <div>
-                          <p className="font-medium text-xs sm:text-sm">
-                            {isTransfer 
-                              ? `Transfer to ${related ? getAccountName(related.account_id) : 'Unknown'}`
-                              : (tx.description || getCategoryName(tx.category_id))
-                            }
+                        <div className="min-w-0">
+                          <p className="font-medium text-xs sm:text-sm flex items-center gap-1.5 min-w-0">
+                            <span className="truncate">
+                              {isTransfer
+                                ? `Transfer to ${related ? getAccountName(related.account_id) : 'Unknown'}`
+                                : (tx.description || getCategoryName(tx.category_id))
+                              }
+                            </span>
+                            {renderRecentBadge(tx)}
                           </p>
                           <div className="flex items-center gap-1.5 sm:gap-2 text-[10px] sm:text-xs text-muted-foreground">
-                            <span>{getAccountName(tx.account_id)}</span>
+                            <span className="truncate">{getAccountName(tx.account_id)}</span>
                             {isTransfer && related && (
                                <>
                                  <span>→</span>
-                                 <span>{getAccountName(related.account_id)}</span>
+                                 <span className="truncate">{getAccountName(related.account_id)}</span>
                                </>
                             )}
                           </div>
@@ -1812,30 +1882,33 @@ export function TransactionList({
                     className="group flex items-center justify-between p-2 sm:p-3 rounded-lg sm:rounded-xl hover:bg-secondary/30 transition-all duration-200"
                     onClick={() => setActiveTxId(activeTxId === tx.id ? null : tx.id)}
                   >
-                    <div className="flex items-center gap-2 sm:gap-3" onClick={(e) => e.stopPropagation()}>
+                    <div className="flex items-center gap-2 sm:gap-3 min-w-0" onClick={(e) => e.stopPropagation()}>
                       <div className={`h-8 w-8 sm:h-10 sm:w-10 rounded-lg sm:rounded-xl flex items-center justify-center text-base sm:text-lg ${
                         isTransfer ? 'bg-blue-500/10 text-blue-500' :
                         tx.amount >= 0 ? 'bg-success/10' : 'bg-secondary'
                       }`}>
                         {isTransfer ? <ArrowRightLeft className="h-4 w-4 sm:h-5 sm:w-5" /> : getCategoryIcon(tx.category_id)}
                       </div>
-                      <div>
-                        <p className="font-medium text-xs sm:text-sm">
-                          {isTransfer 
-                            ? `Transfer to ${related ? getAccountName(related.account_id) : 'Unknown'}`
-                            : (tx.description || getCategoryName(tx.category_id))
-                          }
+                      <div className="min-w-0">
+                        <p className="font-medium text-xs sm:text-sm flex items-center gap-1.5 min-w-0">
+                          <span className="truncate">
+                            {isTransfer
+                              ? `Transfer to ${related ? getAccountName(related.account_id) : 'Unknown'}`
+                              : (tx.description || getCategoryName(tx.category_id))
+                            }
+                          </span>
+                          {renderRecentBadge(tx)}
                         </p>
                         <div className="flex items-center gap-1.5 sm:gap-2 text-[10px] sm:text-xs text-muted-foreground">
                           <span>{new Date(tx.date).getFullYear() !== new Date().getFullYear()
                             ? format(new Date(tx.date), 'MMM d, yyyy')
                             : format(new Date(tx.date), 'MMM d')}</span>
                           <span>•</span>
-                          <span>{getAccountName(tx.account_id)}</span>
+                          <span className="truncate">{getAccountName(tx.account_id)}</span>
                           {isTransfer && related && (
                              <>
                                <span>→</span>
-                               <span>{getAccountName(related.account_id)}</span>
+                               <span className="truncate">{getAccountName(related.account_id)}</span>
                              </>
                           )}
                         </div>

--- a/client/src/components/dashboard-module/TransactionList.tsx
+++ b/client/src/components/dashboard-module/TransactionList.tsx
@@ -881,7 +881,7 @@ export function TransactionList({
         }`}
         onClick={() => setActiveTxId(activeTxId === tx.id ? null : tx.id)}
       >
-        <div className="flex items-center gap-2 sm:gap-3 min-w-0" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center gap-2 sm:gap-3 min-w-0">
           <div className={`h-8 w-8 sm:h-10 sm:w-10 rounded-lg sm:rounded-xl flex items-center justify-center flex-shrink-0 ${
             ready ? 'bg-success/10 text-success' : 'bg-primary/10 text-primary'
           }`}>

--- a/client/src/components/dashboard-module/TransactionList.tsx
+++ b/client/src/components/dashboard-module/TransactionList.tsx
@@ -55,20 +55,25 @@ const isAllTimeRange = (r: { startDate: string; endDate: string }) =>
   r.startDate === '1900-01-01' && r.endDate === '2100-12-31'
 const DISPLAY_LIMIT = 7
 const RECENT_TRANSACTION_MS = 10 * 60 * 1000
+const RECENT_TIMESTAMP_GRACE_MS = 60 * 1000
 const UPDATED_BADGE_GRACE_MS = 1000
 const getLocalDateString = () => format(new Date(), 'yyyy-MM-dd')
+
+const isRecentTimestamp = (timestamp: number, now: number) => {
+  return timestamp > 0
+    && timestamp <= now + RECENT_TIMESTAMP_GRACE_MS
+    && now - timestamp <= RECENT_TRANSACTION_MS
+}
 
 const getRecentTransactionLabel = (tx: Transaction, now: number) => {
   const createdAt = tx.created_at || 0
   const updatedAt = tx.updated_at || 0
-  const isRecentlyCreated = createdAt > 0 && now >= createdAt && now - createdAt <= RECENT_TRANSACTION_MS
-  const isRecentlyUpdated = updatedAt > 0
-    && now >= updatedAt
-    && now - updatedAt <= RECENT_TRANSACTION_MS
+  const isRecentlyCreated = isRecentTimestamp(createdAt, now)
+  const isRecentlyUpdated = isRecentTimestamp(updatedAt, now)
     && (!createdAt || updatedAt > createdAt + UPDATED_BADGE_GRACE_MS)
 
-  if (isRecentlyUpdated) return 'Updated'
-  if (isRecentlyCreated) return 'New'
+  if (isRecentlyUpdated) return 'edited'
+  if (isRecentlyCreated) return 'new'
   return null
 }
 
@@ -142,6 +147,7 @@ export function TransactionList({
   const today = getLocalDateString()
   const isUpcomingForm = formData.type !== 'transfer' && formData.date > today
   const allKnownTransactions = [...transactions, ...upcomingTransactions]
+  const refreshRecentBadges = () => setBadgeNow(Date.now())
 
   // Reset showAllTransactions when filter, sort, search, or date range changes
   useEffect(() => {
@@ -152,6 +158,10 @@ export function TransactionList({
     const interval = window.setInterval(() => setBadgeNow(Date.now()), 30000)
     return () => window.clearInterval(interval)
   }, [])
+
+  useEffect(() => {
+    setBadgeNow(Date.now())
+  }, [transactions, upcomingTransactions])
 
   useEffect(() => {
     apiFetch(`${API_BASE_URL}/categories`)
@@ -559,6 +569,7 @@ export function TransactionList({
       }
       setIsAdding(false)
       resetForm()
+      refreshRecentBadges()
       onTransactionAdded()
       showAlert({
         type: 'success',
@@ -702,6 +713,7 @@ export function TransactionList({
         await apiFetch(`${API_BASE_URL}/transactions/${id}`, { method: 'DELETE' })
       }
       
+      refreshRecentBadges()
       onTransactionAdded()
       showAlert({ type: 'success', message: 'Transaction deleted' })
     } catch (error) {
@@ -729,6 +741,7 @@ export function TransactionList({
         throw new Error(data.error || 'Failed to confirm transaction')
       }
 
+      refreshRecentBadges()
       onTransactionAdded()
       showAlert({ type: 'success', message: 'Upcoming transaction confirmed' })
     } catch (error) {
@@ -805,6 +818,7 @@ export function TransactionList({
     }
     
     setShowBulkModal(false)
+    refreshRecentBadges()
     onTransactionAdded()
     showAlert({
       type: 'success',
@@ -918,7 +932,7 @@ export function TransactionList({
     if (!recentLabel) return null
 
     return (
-      <span className="flex-shrink-0 rounded border border-primary/20 bg-primary/10 px-1 py-0.5 text-[9px] font-semibold uppercase leading-none text-primary">
+      <span className="flex-shrink-0 select-none text-[10px] font-medium lowercase leading-none text-primary/50 animate-pulse">
         {recentLabel}
       </span>
     )

--- a/client/src/components/dashboard-module/TransactionList.tsx
+++ b/client/src/components/dashboard-module/TransactionList.tsx
@@ -54,6 +54,7 @@ const ALL_TIME_RANGE = { startDate: '1900-01-01', endDate: '2100-12-31' }
 const isAllTimeRange = (r: { startDate: string; endDate: string }) =>
   r.startDate === '1900-01-01' && r.endDate === '2100-12-31'
 const DISPLAY_LIMIT = 7
+const getLocalDateString = () => format(new Date(), 'yyyy-MM-dd')
 
 // LocalStorage keys for remembering last used values
 const STORAGE_KEYS = {
@@ -99,7 +100,7 @@ export function TransactionList({
     amount: '',
     amount_to: '',
     description: '',
-    date: new Date().toISOString().split('T')[0],
+    date: getLocalDateString(),
     type: 'expense' as 'expense' | 'income' | 'transfer',
     manual_price: '', // For investment accounts - manual price override
     exclude_from_estimate: false
@@ -121,7 +122,7 @@ export function TransactionList({
   const { confirm, showAlert } = useAlert()
   const { privacyMode, shouldHideInvestment } = usePrivacy()
   const isLocked = (accountId: string) => accounts.find(a => a.id === accountId)?.is_locked ?? false
-  const today = format(new Date(), 'yyyy-MM-dd')
+  const today = getLocalDateString()
   const isUpcomingForm = formData.type !== 'transfer' && formData.date > today
   const allKnownTransactions = [...transactions, ...upcomingTransactions]
 
@@ -393,7 +394,7 @@ export function TransactionList({
       amount: '',
       amount_to: '',
       description: '',
-      date: new Date().toISOString().split('T')[0],
+      date: getLocalDateString(),
       type: 'expense',
       manual_price: '',
       exclude_from_estimate: false
@@ -412,7 +413,7 @@ export function TransactionList({
       amount: '',
       amount_to: '',
       description: '',
-      date: new Date().toISOString().split('T')[0],
+      date: getLocalDateString(),
       type: 'expense',
       manual_price: '',
       exclude_from_estimate: false
@@ -1988,7 +1989,7 @@ export function TransactionList({
         onConfirm={handleBulkTransactionConfirm}
         accounts={accounts}
         categories={categories}
-        defaultDate={new Date().toISOString().split('T')[0]}
+        defaultDate={getLocalDateString()}
       />
     </Card>
   )

--- a/client/src/components/settings-module/components/ScheduledTasksCard.tsx
+++ b/client/src/components/settings-module/components/ScheduledTasksCard.tsx
@@ -21,29 +21,22 @@ export function ScheduledTasksCard() {
 
     setIsTestingSchedule(true)
     try {
-      const res = await apiFetch(`${API_BASE_URL}/test-scheduled-task`, {
+      await apiFetch(`${API_BASE_URL}/test-scheduled-task`, {
         method: 'POST'
       })
 
-      if (res.ok) {
-        showAlert({
-          type: 'success',
-          message: 'Scheduled task executed successfully. Check your transactions.'
-        })
-        setTimeout(() => {
-          window.location.reload()
-        }, 1000)
-      } else {
-        showAlert({
-          type: 'error',
-          message: 'Failed to execute scheduled task. Please try again.'
-        })
-      }
+      showAlert({
+        type: 'success',
+        message: 'Scheduled task executed successfully. Check your transactions.'
+      })
+      setTimeout(() => {
+        window.location.reload()
+      }, 1000)
     } catch (error) {
       console.error('Failed to test scheduled task:', error)
       showAlert({
         type: 'error',
-        message: 'Failed to execute scheduled task. Please try again.'
+        message: error instanceof Error ? error.message : 'Failed to execute scheduled task. Please try again.'
       })
     } finally {
       setIsTestingSchedule(false)

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -26,17 +26,90 @@ const getLocalDateString = () => {
   return `${year}-${month}-${day}`
 }
 
-// Helper function for authenticated API calls
-export const apiFetch = (url: string, options: RequestInit = {}) => {
-  return fetch(url, {
-    ...options,
-    // No credentials needed since we use API key authentication
-    headers: {
-      'X-API-Key': API_KEY,
-      'X-Client-Date': getLocalDateString(),
-      ...options.headers,
-    },
+type ApiFetchOptions = RequestInit & {
+  throwOnError?: boolean
+}
+
+type ApiErrorDetail = {
+  field?: string
+  message?: string
+}
+
+type ApiErrorResponse = {
+  error?: string
+  message?: string
+  code?: string
+  details?: ApiErrorDetail[]
+}
+
+export class ApiRequestError extends Error {
+  status: number
+  code?: string
+  details?: ApiErrorDetail[]
+
+  constructor(message: string, status: number, code?: string, details?: ApiErrorDetail[]) {
+    super(message)
+    this.name = 'ApiRequestError'
+    this.status = status
+    this.code = code
+    this.details = details
+  }
+}
+
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
+
+const buildHeaders = (headers?: HeadersInit) => {
+  const next = new Headers({
+    'X-API-Key': API_KEY,
+    'X-Client-Date': getLocalDateString(),
   })
+
+  new Headers(headers).forEach((value, key) => {
+    next.set(key, value)
+  })
+
+  return next
+}
+
+const createApiRequestError = async (response: Response) => {
+  const fallback = `Request failed (${response.status})`
+
+  try {
+    const data = await response.clone().json() as ApiErrorResponse
+    const details = Array.isArray(data.details) ? data.details : undefined
+    const detailMessage = details
+      ?.map(detail => {
+        if (!detail.message) return ''
+        return detail.field ? `${detail.field}: ${detail.message}` : detail.message
+      })
+      .filter(Boolean)
+      .join('; ')
+
+    const mainMessage = data.error || data.message || fallback
+    const message = detailMessage ? `${mainMessage}: ${detailMessage}` : mainMessage
+
+    return new ApiRequestError(message, response.status, data.code, details)
+  } catch {
+    const text = await response.clone().text().catch(() => '')
+    return new ApiRequestError(text || fallback, response.status)
+  }
+}
+
+// Helper function for authenticated API calls
+export const apiFetch = async (url: string, options: ApiFetchOptions = {}) => {
+  const { throwOnError, headers, ...fetchOptions } = options
+  const method = (fetchOptions.method || 'GET').toUpperCase()
+  const response = await fetch(url, {
+    ...fetchOptions,
+    // No credentials needed since we use API key authentication
+    headers: buildHeaders(headers),
+  })
+
+  if (!response.ok && (throwOnError ?? MUTATING_METHODS.has(method))) {
+    throw await createApiRequestError(response)
+  }
+
+  return response
 }
 
 // ===========================================

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -18,6 +18,14 @@ export const API_BASE_URL = isDev
 // API Key for authentication
 const API_KEY = import.meta.env.VITE_API_KEY || ''
 
+const getLocalDateString = () => {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 // Helper function for authenticated API calls
 export const apiFetch = (url: string, options: RequestInit = {}) => {
   return fetch(url, {
@@ -25,6 +33,7 @@ export const apiFetch = (url: string, options: RequestInit = {}) => {
     // No credentials needed since we use API key authentication
     headers: {
       'X-API-Key': API_KEY,
+      'X-Client-Date': getLocalDateString(),
       ...options.headers,
     },
   })

--- a/client/src/hooks/useFinanceData.ts
+++ b/client/src/hooks/useFinanceData.ts
@@ -25,6 +25,11 @@ export type Transaction = {
   date: string
   linked_transaction_id?: string
   exclude_from_estimate?: boolean
+  status?: 'posted' | 'pending' | 'cancelled'
+  confirmed_at?: number | null
+  cancelled_at?: number | null
+  created_at?: number | null
+  updated_at?: number | null
 }
 
 export type Category = {
@@ -53,6 +58,7 @@ export function useFinanceData(
   const [accounts, setAccounts] = useState<Account[]>([])
   const [transactions, setTransactions] = useState<Transaction[]>([])
   const [allTransactions, setAllTransactions] = useState<Transaction[]>([])
+  const [upcomingTransactions, setUpcomingTransactions] = useState<Transaction[]>([])
   const [transactionsLoading, setTransactionsLoading] = useState<boolean>(true)
   const [categories, setCategories] = useState<Category[]>([])
   const [exchangeRates, setExchangeRates] = useState<Record<string, number>>({})
@@ -75,6 +81,10 @@ export function useFinanceData(
     const regularTxPromise = apiFetch(
       `${API_BASE_URL}/transactions/date-range?startDate=${dateRange.startDate}&endDate=${dateRange.endDate}`
     )
+      .then(res => res.json())
+      .catch(() => [])
+
+    const upcomingTxPromise = apiFetch(`${API_BASE_URL}/transactions/upcoming`)
       .then(res => res.json())
       .catch(() => [])
 
@@ -101,11 +111,12 @@ export function useFinanceData(
         .catch(() => [])
     )
 
-    const [regularTxs, ...investmentTxArrays] = await Promise.all([regularTxPromise, ...investmentTxPromises])
+    const [regularTxs, upcomingTxs, ...investmentTxArrays] = await Promise.all([regularTxPromise, upcomingTxPromise, ...investmentTxPromises])
     const allTxs = [...regularTxs, ...investmentTxArrays.flat()].sort(
       (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
     )
     setTransactions(allTxs)
+    setUpcomingTransactions(upcomingTxs)
 
     apiFetch(`${API_BASE_URL}/categories`)
       .then(res => res.json())
@@ -278,6 +289,7 @@ export function useFinanceData(
     accounts,
     transactions,
     allTransactions,
+    upcomingTransactions,
     transactionsLoading,
     categories,
     exchangeRates,

--- a/client/src/hooks/useFinanceData.ts
+++ b/client/src/hooks/useFinanceData.ts
@@ -106,6 +106,8 @@ export function useFinanceData(
               is_recurring: false,
               category_id: undefined,
               linked_transaction_id: undefined,
+              created_at: itx.created_at,
+              updated_at: itx.updated_at ?? itx.created_at,
             }))
         )
         .catch(() => [])
@@ -150,6 +152,8 @@ export function useFinanceData(
               date: itx.date,
               category_id: undefined,
               linked_transaction_id: undefined,
+              created_at: itx.created_at,
+              updated_at: itx.updated_at ?? itx.created_at,
             }))
           )
           .catch(() => [])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finance-manager",
-  "version": "2.3",
+  "version": "2.4",
   "private": true,
   "workspaces": [
     "client",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finance-manager",
-  "version": "2.1",
+  "version": "2.2",
   "private": true,
   "workspaces": [
     "client",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finance-manager",
-  "version": "2.2",
+  "version": "2.3",
   "private": true,
   "workspaces": [
     "client",


### PR DESCRIPTION
## Summary
- Add one-time upcoming transactions for future-dated income/expense entries, separate from recurring schedules.
- Keep upcoming transactions pinned above the transaction list as `Upcoming` or `Ready to confirm`, with confirm/decline actions once the date is today or past.
- Include projected dashboard and analytics views so pending money can be understood without affecting posted balances early.
- Add small temporary `New` / `Updated` badges on recently created or edited transactions for about 10 minutes.
- Improve frontend feedback across the app so successful actions and server validation errors are visible to the user.

## API and Data Changes
- Add transaction `status`, `confirmed_at`, `cancelled_at`, and timestamp handling, plus migration support.
- Add upcoming transaction endpoints: `GET /transactions/upcoming`, `POST /transactions/:id/confirm`, and `POST /transactions/:id/decline`.
- Keep pending/cancelled transactions out of posted transaction history and balance calculations until confirmation.
- Use the client calendar date via `X-Client-Date` so UI and API agree on what counts as today.
- Allow uncategorized transaction creates/updates by accepting `category_id: null`.

## Bug Fixes and Hardening
- Prevent transfers and linked transfer rows from becoming upcoming transactions.
- Block confirm/decline for linked transfers, and reject confirmation for transactions still dated in the future.
- Make pending confirmation idempotent and safer against double-confirm races.
- Prevent a pending transaction from being marked posted unless the balance update is applied.
- Map user-correctable transaction errors to `400` responses instead of generic server errors.
- Fix upcoming row click handling so pending rows can be expanded/collapsed normally.
- Update transfer-pair edit timestamps so edited transfers can show the temporary `Updated` badge.
- Preserve backend validation messages in the frontend instead of replacing them with generic errors.

## User Feedback Improvements
- Transaction create/edit/delete/confirm/decline now shows success or a real server error.
- Bulk transaction failures now surface in an alert instead of only logging to the console.
- Account save/delete/lock/exclusion/adjustment actions now show visible success/error feedback.
- Budget save/delete failures show both modal/inline feedback and alerts, with success alerts after saves/deletes.
- Recurring schedule save/delete/toggle actions now show parsed API errors and correctly clear submitting state.
- Scheduled task test failures now show the API error message.

## Verification
- api: `npm test`
- client: `npm test`
- client: `npm run build`
- lint-style check: `git diff --check`
- browser smoke: reloaded `http://localhost:5173/` and verified no console errors
- earlier smoke: created a future transaction through a local worker, verified it stayed pending without balance impact, then confirmed it and verified the balance updated
